### PR TITLE
Fix date labels and return updated raceday

### DIFF
--- a/backend/src/raceday/raceday-service.js
+++ b/backend/src/raceday/raceday-service.js
@@ -30,9 +30,9 @@ const updateEarliestUpdatedHorseTimestamp = async (raceDayId, targetRaceId) => {
       // Mark the sub-document as modified to ensure it gets saved
       raceDay.markModified('raceList');
       await raceDay.save();
-      
+
       console.log('Race day saved.');
-      break;
+      return raceDay;
     }
   }
 

--- a/frontend/src/composables/useDateFormat.js
+++ b/frontend/src/composables/useDateFormat.js
@@ -1,6 +1,6 @@
 export const useDateFormat = () => {
     const formatDate = (dateString) => {
-        const days = ['SÖNDAG', 'MÅNDAG', 'TISDAG', 'ONSDAG', 'TORS DAG', 'FREDAG', 'LÖRDAG']
+        const days = ['SÖNDAG', 'MÅNDAG', 'TISDAG', 'ONSDAG', 'TORSDAG', 'FREDAG', 'LÖRDAG']
         const months = ['JANUARI', 'FEBRUARI', 'MARS', 'APRIL', 'MAJ', 'JUNI', 'JULI', 'AUGUSTI', 'SEPTEMBER', 'OKTOBER', 'NOVEMBER', 'DECEMBER']
         const date = new Date(dateString)
         const dayName = days[date.getDay()]


### PR DESCRIPTION
## Summary
- return the updated raceday document from `updateEarliestUpdatedHorseTimestamp`
- fix Swedish weekday string for Thursday in the date formatting helper

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: dependency resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_6887243373d48330b56cd853e362b566