### PR TITLE
Fix raceday list NaN

### DIFF
--- a/backend/src/raceday/raceday-service.js
+++ b/backend/src/raceday/raceday-service.js
@@ -46,10 +46,14 @@ const updateEarliestUpdatedHorseTimestamp = async (raceDayId, targetRaceId) => {
 }
 
 const upsertStartlistData = async (racedayJSON) => {
-    const raceDayId = racedayJSON.raceDayId;
+    const raceDayId = racedayJSON.raceDayId
     let raceDay
     try {
-        raceDay = await Raceday.updateOne({ raceDayId: raceDayId }, racedayJSON, { upsert: true, new: true })
+        raceDay = await Raceday.findOneAndUpdate(
+            { raceDayId: raceDayId },
+            racedayJSON,
+            { upsert: true, new: true, runValidators: true }
+        )
     } catch (error) {
         console.error(`Error while upserting the startlist with raceDayId ${raceDayId}:`, error)
         throw error

--- a/frontend/src/views/RacedayInput/store.js
+++ b/frontend/src/views/RacedayInput/store.js
@@ -22,9 +22,9 @@ const mutations = {
     setSuccessMessage(state, message) {
         state.successMessage = message
     },
-    addRaceDay(state, raceDayId) {
-        if (!state.raceDays.includes(raceDayId)) {
-            state.raceDays.push(raceDayId)
+    addRaceDay(state, raceDay) {
+        if (!state.raceDays.find(rd => rd._id === raceDay._id)) {
+            state.raceDays.push(raceDay)
         }
     },
     setRaceDays(state, raceDays) {
@@ -39,7 +39,7 @@ const actions = {
             const response = await addRaceday(data)
             commit('setRacedayData', response)
             commit('setSuccessMessage', 'Raceday data uploaded successfully!')
-            commit('addRaceDay', data.raceDayId)
+            commit('addRaceDay', response)
         } catch (error) {
             commit('setError', error.message)
         } finally {


### PR DESCRIPTION
## Summary
- return the full raceday document when upserting startlists in the backend
- store the returned raceday object so newly added days appear correctly

## Testing
- `yarn test` *(fails: Couldn't find a script named "test")*
- `npm test` *(fails: missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68872fbccb008330831da1f8cea5b8ff