### PR TITLE
Sort Raceday list by most recent

### DIFF
--- a/backend/src/raceday/raceday-service.js
+++ b/backend/src/raceday/raceday-service.js
@@ -59,7 +59,8 @@ const upsertStartlistData = async (racedayJSON) => {
 
 const getAllRacedays = async () => {
     try {
-        return await Raceday.find({})
+        // Sort by firstStart in descending order so the latest raceday appears first
+        return await Raceday.find({}).sort({ firstStart: -1 })
     } catch (error) {
         console.error('Error in getAllRacedays:', error)
         throw error

--- a/frontend/src/views/RacedayInput/store.js
+++ b/frontend/src/views/RacedayInput/store.js
@@ -49,11 +49,13 @@ const actions = {
     async fetchRacedays({ commit }) {
         try {
           const response = await axios.get(`${import.meta.env.VITE_BE_URL}/api/raceday`)
-          commit('setRaceDays', response.data)
+          // Ensure racedays are sorted with the latest first
+          const sorted = response.data.sort((a, b) => new Date(b.firstStart) - new Date(a.firstStart))
+          commit('setRaceDays', sorted)
         } catch (error) {
           console.error('Error fetching racedays:', error)
         }
-    }     
+    }
 }
 
 export default {


### PR DESCRIPTION
## Summary
- return latest raceday first from API
- ensure frontend sorts raceday list by date

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68872fdee5588330804b9dc694e53090