### PR TITLE
Add lazy loading for raceday list

### DIFF
--- a/backend/src/raceday/raceday-routes.js
+++ b/backend/src/raceday/raceday-routes.js
@@ -23,7 +23,9 @@ router.post('/', async (req, res) => {
 router.get('/', async (req, res) => {
     console.log('req:', req.originalUrl)
     try {
-        const racedays = await raceDayService.getAllRacedays()
+        const skip = parseInt(req.query.skip) || 0
+        const limit = req.query.limit ? parseInt(req.query.limit) : null
+        const racedays = await raceDayService.getAllRacedays(skip, limit)
         res.send(racedays)
     } catch (error) {
         console.error('Error fetching all racedays:', error);

--- a/backend/src/raceday/raceday-service.js
+++ b/backend/src/raceday/raceday-service.js
@@ -57,9 +57,12 @@ const upsertStartlistData = async (racedayJSON) => {
     return raceDay
 }
 
-const getAllRacedays = async () => {
+const getAllRacedays = async (skip = 0, limit = null) => {
     try {
-        return await Raceday.find({})
+        const query = Raceday.find({}).sort({ firstStart: -1 })
+        if (skip) query.skip(skip)
+        if (limit) query.limit(limit)
+        return await query.exec()
     } catch (error) {
         console.error('Error in getAllRacedays:', error)
         throw error

--- a/frontend/src/views/RacedayInput/RacedayInputView.vue
+++ b/frontend/src/views/RacedayInput/RacedayInputView.vue
@@ -27,6 +27,7 @@
             </v-list-item>
             <v-divider></v-divider>
         </template>
+        <div ref="infiniteScrollTrigger" class="infinite-scroll-trigger"></div>
     </v-list>
 
   </v-container>
@@ -54,10 +55,12 @@ export default {
     const racedayJsonInput = ref('');
     const showSnackbar = ref(false);
 
-    const error = computed(() => store.state.raceday.error);
+    const error = computed(() => store.state.racedayInput.error);
     const raceDays = computed(() => store.state.racedayInput.raceDays);
-    const loading = computed(() => store.state.raceday.loading);
-    const successMessage = computed(() => store.state.raceday.successMessage);
+    const loading = computed(() => store.state.racedayInput.loading || store.state.racedayInput.listLoading);
+    const successMessage = computed(() => store.state.racedayInput.successMessage);
+    const hasMore = computed(() => store.state.racedayInput.hasMore);
+    const infiniteScrollTrigger = ref(null);
 
     const submitRacedayData = () => {
       if (racedayJsonInput.value === '') return;
@@ -82,8 +85,17 @@ export default {
       }
     });
 
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && hasMore.value) {
+        store.dispatch('racedayInput/fetchRacedays');
+      }
+    });
+
     onMounted(() => {
-      store.dispatch('racedayInput/fetchRacedays');
+      store.dispatch('racedayInput/fetchRacedays', { reset: true });
+      if (infiniteScrollTrigger.value) {
+        observer.observe(infiniteScrollTrigger.value);
+      }
     });
 
     return {
@@ -95,7 +107,9 @@ export default {
       loading,
       successMessage,
       submitRacedayData,
-      navigateToRaceDay
+      navigateToRaceDay,
+      infiniteScrollTrigger,
+      hasMore
     };
   }
 }
@@ -107,5 +121,8 @@ export default {
   }
   .main-content {
     padding-top: 70px;
+  }
+  .infinite-scroll-trigger {
+    height: 1px;
   }
 </style>

--- a/frontend/src/views/RacedayInput/store.js
+++ b/frontend/src/views/RacedayInput/store.js
@@ -4,9 +4,13 @@ import { addRaceday } from './services/RacedayInputService.js'
 const state = {
     racedayData: {},
     loading: false,
+    listLoading: false,
     error: null,
     successMessage: null,
-    raceDays: []
+    raceDays: [],
+    page: 0,
+    pageSize: 10,
+    hasMore: true
 }
 
 const mutations = {
@@ -29,7 +33,22 @@ const mutations = {
     },
     setRaceDays(state, raceDays) {
         state.raceDays = raceDays
-    }    
+    },
+    appendRaceDays(state, raceDays) {
+        state.raceDays.push(...raceDays)
+    },
+    setListLoading(state, loading) {
+        state.listLoading = loading
+    },
+    setPage(state, page) {
+        state.page = page
+    },
+    incrementPage(state) {
+        state.page++
+    },
+    setHasMore(state, hasMore) {
+        state.hasMore = hasMore
+    }
 }
 
 const actions = {
@@ -46,14 +65,39 @@ const actions = {
             commit('setLoading', false)
         }
     },
-    async fetchRacedays({ commit }) {
+    async fetchRacedays({ commit, state }, { reset = false } = {}) {
+        if (state.listLoading) return
+        if (reset) {
+            commit('setRaceDays', [])
+            commit('setPage', 0)
+            commit('setHasMore', true)
+        }
+        if (!state.hasMore && !reset) return
+
+        const skip = state.page * state.pageSize
+        const limit = state.pageSize
+        commit('setListLoading', true)
         try {
-          const response = await axios.get(`${import.meta.env.VITE_BE_URL}/api/raceday`)
-          commit('setRaceDays', response.data)
+          const response = await axios.get(`${import.meta.env.VITE_BE_URL}/api/raceday`, {
+            params: { skip, limit }
+          })
+          const fetched = response.data
+          if (reset) {
+            commit('setRaceDays', fetched)
+          } else {
+            commit('appendRaceDays', fetched)
+          }
+          commit('incrementPage')
+          if (fetched.length < state.pageSize) {
+            commit('setHasMore', false)
+          }
         } catch (error) {
           console.error('Error fetching racedays:', error)
+          commit('setHasMore', false)
+        } finally {
+          commit('setListLoading', false)
         }
-    }     
+    }
 }
 
 export default {


### PR DESCRIPTION
## Summary
- provide pagination support in backend API for fetching raceday items
- update store to fetch lists page by page
- implement infinite scroll in `RacedayInputView`

## Testing
- `npm test --workspaces` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6887303d27b48330ade2cd62ae9def1a