### PR TITLE
Add automatic raceday fetch feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ The Vue application will be available at <http://localhost:5173> by default and 
 
 The `mongodb-scripts` folder contains aggregation pipelines exported from MongoDB Compass. They can be loaded in the Aggregations tab of Compass for experimenting with ranking logic.
 
+## Fetching raceday data automatically
+
+To import startlists from the official Travsport API, the back‑end exposes a POST
+endpoint:
+
+```
+POST /api/raceday/fetch?date=YYYY-MM-DD
+```
+
+It downloads all raceday startlists for the given date and stores them in MongoDB.
+The front‑end provides a date field in the **Raceday Input** view where you can
+trigger this fetch.
+
 ## Building for production
 
 To create optimized builds:

--- a/backend/src/raceday/raceday-routes.js
+++ b/backend/src/raceday/raceday-routes.js
@@ -4,6 +4,21 @@ import { validateNumericParam, validateObjectIdParam } from '../middleware/valid
 
 const router = express.Router()
 
+// Fetch raceday data from the external API and store it
+router.post('/fetch', async (req, res) => {
+    const date = req.query.date
+    if (!date) {
+        return res.status(400).send('Missing date parameter')
+    }
+    try {
+        const result = await raceDayService.fetchAndStoreByDate(date)
+        res.send(result)
+    } catch (error) {
+        console.error('Error fetching raceday data from external API:', error)
+        res.status(500).send('Failed to fetch raceday data')
+    }
+})
+
 router.post('/', async (req, res) => {
     console.log('req:', req.originalUrl)
     try {

--- a/frontend/src/views/RacedayInput/RacedayInputView.vue
+++ b/frontend/src/views/RacedayInput/RacedayInputView.vue
@@ -13,6 +13,14 @@
       </v-col>
     </v-row>
 
+    <!-- Fetch Raceday by Date Section -->
+    <v-row class="mt-4">
+      <v-col>
+        <v-text-field v-model="fetchDate" type="date" label="Fetch Racedays by Date"></v-text-field>
+        <v-btn @click="fetchRacedays" color="primary">Fetch</v-btn>
+      </v-col>
+    </v-row>
+
     <!-- List of Racedays -->
     <v-list>
         <template v-for="raceDay in raceDays" :key="raceDay._id">
@@ -53,6 +61,7 @@ export default {
     const { formatDate } = useDateFormat();
 
     const racedayJsonInput = ref('');
+    const fetchDate = ref('');
     const showSnackbar = ref(false);
 
     const error = computed(() => store.state.racedayInput.error);
@@ -74,6 +83,12 @@ export default {
       }
     };
 
+    const fetchRacedays = () => {
+      if (fetchDate.value) {
+        store.dispatch('racedayInput/fetchRacedaysFromAPI', fetchDate.value);
+      }
+    };
+
     const navigateToRaceDay = (raceDayId) => {
       router.push({ name: 'Raceday', params: { racedayId: raceDayId } }); // Changed this.$router to router
     };
@@ -82,6 +97,7 @@ export default {
       if (successMessage.value) {
         showSnackbar.value = true;
         racedayJsonInput.value = '';
+        fetchDate.value = '';
       }
     });
 
@@ -101,12 +117,14 @@ export default {
     return {
       formatDate,
       racedayJsonInput,
+      fetchDate,
       showSnackbar,
       error,
       raceDays,
       loading,
       successMessage,
       submitRacedayData,
+      fetchRacedays,
       navigateToRaceDay,
       infiniteScrollTrigger,
       hasMore

--- a/frontend/src/views/RacedayInput/services/RacedayInputService.js
+++ b/frontend/src/views/RacedayInput/services/RacedayInputService.js
@@ -13,3 +13,13 @@ export async function addRaceday(racedayData) {
 
   return await response.json()
 }
+
+export async function fetchRacedaysByDate(date) {
+  const response = await fetch(`${import.meta.env.VITE_BE_URL}/api/raceday/fetch?date=${date}`, {
+      method: 'POST'
+  })
+  if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`)
+  }
+  return await response.json()
+}

--- a/frontend/src/views/RacedayInput/store.js
+++ b/frontend/src/views/RacedayInput/store.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { addRaceday } from './services/RacedayInputService.js'
+import { addRaceday, fetchRacedaysByDate } from './services/RacedayInputService.js'
 
 const state = {
     racedayData: {},
@@ -59,6 +59,18 @@ const actions = {
             commit('setRacedayData', response)
             commit('setSuccessMessage', 'Raceday data uploaded successfully!')
             commit('addRaceDay', response)
+        } catch (error) {
+            commit('setError', error.message)
+        } finally {
+            commit('setLoading', false)
+        }
+    },
+    async fetchRacedaysFromAPI({ commit }, date) {
+        commit('setLoading', true)
+        try {
+            const response = await fetchRacedaysByDate(date)
+            response.forEach(r => commit('addRaceDay', r))
+            commit('setSuccessMessage', 'Raceday data fetched successfully!')
         } catch (error) {
             commit('setError', error.message)
         } finally {


### PR DESCRIPTION
## Summary
- support fetching raceday IDs from Travsport API and storing them
- expose POST `/api/raceday/fetch` endpoint on the backend
- allow frontend users to fetch raceday data by date
- document the new endpoint in README

## Testing
- `yarn install` in `frontend`
- `yarn build` in `frontend`
- `yarn install` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_68873a266d148330846e7cfe57101ead