### PR TITLE
Remove obsolete manual raceday upload UI

### DIFF
--- a/frontend/src/views/RacedayInput/RacedayInputView.vue
+++ b/frontend/src/views/RacedayInput/RacedayInputView.vue
@@ -2,22 +2,12 @@
   <v-container fluid class="main-content">
     <v-progress-circular v-if="loading" indeterminate color="primary"></v-progress-circular>
 
-    <!-- Raceday JSON Input Section -->
-    <v-row>
-      <v-col>
-        <v-form @submit.prevent="submitRacedayData">
-          <v-textarea v-model="racedayJsonInput" label="Raceday JSON Data" required variant="outlined"></v-textarea>
-          <v-btn type="submit" color="primary">Submit Raceday Data</v-btn>
-        </v-form>
-        <v-alert v-if="error" type="error">{{ error }}</v-alert>
-      </v-col>
-    </v-row>
-
     <!-- Fetch Raceday by Date Section -->
     <v-row class="mt-4">
       <v-col>
         <v-text-field v-model="fetchDate" type="date" label="Fetch Racedays by Date"></v-text-field>
         <v-btn @click="fetchRacedays" color="primary">Fetch</v-btn>
+        <v-alert v-if="error" type="error" class="mt-2">{{ error }}</v-alert>
       </v-col>
     </v-row>
 
@@ -60,7 +50,6 @@ export default {
     const router = useRouter();
     const { formatDate } = useDateFormat();
 
-    const racedayJsonInput = ref('');
     const fetchDate = ref('');
     const showSnackbar = ref(false);
 
@@ -71,17 +60,6 @@ export default {
     const hasMore = computed(() => store.state.racedayInput.hasMore);
     const infiniteScrollTrigger = ref(null);
 
-    const submitRacedayData = () => {
-      if (racedayJsonInput.value === '') return;
-
-      try {
-        const parsedData = JSON.parse(racedayJsonInput.value);
-        store.dispatch('racedayInput/addRacedayData', parsedData);
-        racedayJsonInput.value = '';  // Clear input after successful submission
-      } catch (error) {
-        console.error('Error parsing Raceday JSON data:', error);
-      }
-    };
 
     const fetchRacedays = () => {
       if (fetchDate.value) {
@@ -96,7 +74,6 @@ export default {
     watchEffect(() => {
       if (successMessage.value) {
         showSnackbar.value = true;
-        racedayJsonInput.value = '';
         fetchDate.value = '';
       }
     });
@@ -116,14 +93,12 @@ export default {
 
     return {
       formatDate,
-      racedayJsonInput,
       fetchDate,
       showSnackbar,
       error,
       raceDays,
       loading,
       successMessage,
-      submitRacedayData,
       fetchRacedays,
       navigateToRaceDay,
       infiniteScrollTrigger,

--- a/frontend/src/views/RacedayInput/services/RacedayInputService.js
+++ b/frontend/src/views/RacedayInput/services/RacedayInputService.js
@@ -1,19 +1,3 @@
-export async function addRaceday(racedayData) {
-  const response = await fetch(`${import.meta.env.VITE_BE_URL}/api/raceday`, {
-      method: 'POST',
-      headers: {
-          'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(racedayData)
-  })
-
-  if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`)
-  }
-
-  return await response.json()
-}
-
 export async function fetchRacedaysByDate(date) {
   const response = await fetch(`${import.meta.env.VITE_BE_URL}/api/raceday/fetch?date=${date}`, {
       method: 'POST'

--- a/frontend/src/views/RacedayInput/store.js
+++ b/frontend/src/views/RacedayInput/store.js
@@ -1,8 +1,7 @@
 import axios from 'axios'
-import { addRaceday, fetchRacedaysByDate } from './services/RacedayInputService.js'
+import { fetchRacedaysByDate } from './services/RacedayInputService.js'
 
 const state = {
-    racedayData: {},
     loading: false,
     listLoading: false,
     error: null,
@@ -14,9 +13,6 @@ const state = {
 }
 
 const mutations = {
-    setRacedayData(state, data) {
-        state.racedayData = data
-    },
     setLoading(state, loading) {
         state.loading = loading
     },
@@ -52,19 +48,6 @@ const mutations = {
 }
 
 const actions = {
-    async addRacedayData({ commit }, data) {
-        commit('setLoading', true)
-        try {
-            const response = await addRaceday(data)
-            commit('setRacedayData', response)
-            commit('setSuccessMessage', 'Raceday data uploaded successfully!')
-            commit('addRaceDay', response)
-        } catch (error) {
-            commit('setError', error.message)
-        } finally {
-            commit('setLoading', false)
-        }
-    },
     async fetchRacedaysFromAPI({ commit }, date) {
         commit('setLoading', true)
         try {


### PR DESCRIPTION
## Summary
- clean up `RacedayInputView` by removing the JSON upload form
- drop unused `addRaceday` service and store action

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68874c0e58f88330a10e3ee1595b2947