### PR TITLE
Implement race-level update action

### DIFF
--- a/frontend/src/views/RaceHorses/RaceHorsesView.vue
+++ b/frontend/src/views/RaceHorses/RaceHorsesView.vue
@@ -26,8 +26,7 @@
                                 </span>
                             </template>
                             <template v-slot:item.action="{ item }">
-                                <v-btn v-if="!isHorseUpdated(item.key)" @click="updateHorseData(item.key)">Update</v-btn>
-                                <v-icon v-else>mdi-check</v-icon>
+                                <v-icon v-if="isHorseUpdated(item.key)">mdi-check</v-icon>
                             </template>
                         </v-data-table>
                     </v-window-item>
@@ -207,25 +206,11 @@ export default {
             return updatedHorses.value.includes(horseId)
         }
 
-        const updateHorseData = async horseId => {
-            
-            try {
-                await updateHorse(horseId)
-                console.log('Raceday ID:', route.params.racedayId)
-                await setEarliestUpdatedHorseTimestamp(route.params.racedayId, route.params.raceId)
-                const updated = await checkIfUpdatedRecently(horseId)
-                if (updated && !updatedHorses.value.includes(horseId)) {
-                    updatedHorses.value.push(horseId)
-                }
-            } catch (error) {
-                console.error(`Failed to update horse with ID ${horseId}:`, error)
-            }
-        }
+
 
         return {
             headers,
             isHorseUpdated,
-            updateHorseData,
             rankHorses,
             getTrackName,
             navigateToRaceDay,

--- a/frontend/src/views/Raceday/RacedayView.vue
+++ b/frontend/src/views/Raceday/RacedayView.vue
@@ -6,7 +6,12 @@
         <div v-if="racedayDetails">
           <h1>{{ formatDate(racedayDetails.firstStart) }}</h1>
           <div v-for="race in sortedRaceList" :key="race.id">
-            <RaceCardComponent :race="race" :lastUpdatedHorseTimestamp="race.earliestUpdatedHorseTimestamp" :racedayId="reactiveRouteParams.racedayId" />
+            <RaceCardComponent
+              :race="race"
+              :lastUpdatedHorseTimestamp="race.earliestUpdatedHorseTimestamp"
+              :racedayId="reactiveRouteParams.racedayId"
+              @race-updated="refreshRaceday"
+            />
             <div v-if="isRecentlyUpdated(race.earliestUpdatedHorseTimestamp)">
               <v-chip color="green">Updated</v-chip>
             </div>
@@ -57,9 +62,17 @@ export default {
       }
     })
 
+    const refreshRaceday = async () => {
+      try {
+        racedayDetails.value = await RacedayService.fetchRacedayDetails(route.params.racedayId)
+      } catch (error) {
+        console.error('Error refreshing raceday details:', error)
+      }
+    }
+
     const sortedRaceList = computed(() => {
       return racedayDetails.value?.raceList.sort((a, b) => a.raceNumber - b.raceNumber) || []
-    }) 
+    })
 
     return {
       racedayDetails,
@@ -67,7 +80,8 @@ export default {
       formatDate,
       sortedRaceList,
       reactiveRouteParams,
-      isRecentlyUpdated
+      isRecentlyUpdated,
+      refreshRaceday
     }
   }
 }

--- a/frontend/src/views/Raceday/components/RaceCardComponent.vue
+++ b/frontend/src/views/Raceday/components/RaceCardComponent.vue
@@ -12,15 +12,20 @@
       </v-card-text>
       <v-card-actions>
         <v-btn @click.stop="viewRaceDetails">View Details</v-btn>
+        <v-btn @click.stop="updateRace" :disabled="loading" class="ml-2">
+          {{ loading ? 'Updating…' : 'Update Race' }}
+        </v-btn>
       </v-card-actions>
     </div>
+    <v-alert v-if="errorMessage" type="error" class="ma-2">{{ errorMessage }}</v-alert>
   </v-card>
 </template>
 
 <script>
-import { toRefs } from 'vue'
+import { toRefs, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useStore } from 'vuex'
+import { updateHorse, setEarliestUpdatedHorseTimestamp } from '@/views/RaceHorses/services/RaceHorsesService.js'
 
 export default {
   props: {
@@ -37,11 +42,13 @@ export default {
       required: true
     }
   },
-  setup(props) {
+  setup(props, { emit }) {
     // Convert props to reactive references
     const { race, lastUpdatedHorseTimestamp } = toRefs(props)
     const router = useRouter()
     const store = useStore()
+    const loading = ref(false)
+    const errorMessage = ref('')
 
     const viewRaceDetails = () => {
       store.commit('raceHorses/setCurrentRace', props.race);
@@ -54,12 +61,36 @@ export default {
         });
     };
 
+    const updateRace = async () => {
+      loading.value = true
+      errorMessage.value = ''
+      for (const h of props.race.horses || []) {
+        try {
+          await updateHorse(h.id)
+          await new Promise(r => setTimeout(r, 200))
+        } catch (err) {
+          console.error(`Failed to update horse ${h.id}:`, err)
+          errorMessage.value = 'Failed to update some horses'
+        }
+      }
+      try {
+        await setEarliestUpdatedHorseTimestamp(props.racedayId, props.race.raceId)
+      } catch (err) {
+        console.error('Failed to set earliest updated timestamp', err)
+      }
+      loading.value = false
+      emit('race-updated')
+    }
+
 
 
     return {
       race,
       lastUpdatedHorseTimestamp,
-      viewRaceDetails
+      viewRaceDetails,
+      updateRace,
+      loading,
+      errorMessage
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove per-horse update buttons from RaceHorsesView
- add race-wide Update Race button to RaceCardComponent
- wire up sequential update logic with loading and error state
- refresh raceday details when a race finishes updating

## Testing
- `npx vite build`

------
https://chatgpt.com/codex/tasks/task_e_68876bfae45083308e722173e00a137d