### PR TITLE
Remove outdated updated badge

### DIFF
--- a/frontend/src/views/Raceday/RacedayView.vue
+++ b/frontend/src/views/Raceday/RacedayView.vue
@@ -12,9 +12,6 @@
               :racedayId="reactiveRouteParams.racedayId"
               @race-updated="refreshRaceday"
             />
-            <div v-if="isRecentlyUpdated(race.earliestUpdatedHorseTimestamp)">
-              <v-chip color="green">Updated</v-chip>
-            </div>
           </div>
         </div>
         <div v-else-if="errorMessage" class="error-message">


### PR DESCRIPTION
## Summary
- remove the `Updated` badge from the Raceday view

## Testing
- `yarn -v`

------
https://chatgpt.com/codex/tasks/task_e_6887756b74b883309ec111342eddca80