### PR TITLE
Improve horse scoring model

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ VITE_BE_URL=http://localhost:3001
 
 The back‑end server uses port `3001` by default. Adjust the value if you run the server on another port.
 
+The ranking logic uses a weighted score. You can override the default weights with environment variables in the back‑end:
+
+```bash
+# optional scoring weights
+SCORE_WEIGHT_POINTS=0.30
+SCORE_WEIGHT_CONSISTENCY=0.30
+SCORE_WEIGHT_WIN_RATE=0.25
+SCORE_WEIGHT_PLACEMENT_RATE=0.15
+```
+
 ### 3. Starting MongoDB
 
 Make sure a MongoDB instance is running on `mongodb://localhost:27017`. The back‑end connects to a database named `winv75`.

--- a/backend/src/config/scoring.js
+++ b/backend/src/config/scoring.js
@@ -1,0 +1,18 @@
+export const DEFAULT_WEIGHTS = {
+  points: 0.30,
+  consistency: 0.30,
+  winRate: 0.25,
+  placementRate: 0.15
+}
+
+export function getWeights() {
+  return {
+    points: Number(process.env.SCORE_WEIGHT_POINTS) || DEFAULT_WEIGHTS.points,
+    consistency: Number(process.env.SCORE_WEIGHT_CONSISTENCY) || DEFAULT_WEIGHTS.consistency,
+    winRate: Number(process.env.SCORE_WEIGHT_WIN_RATE) || DEFAULT_WEIGHTS.winRate,
+    placementRate: Number(process.env.SCORE_WEIGHT_PLACEMENT_RATE) || DEFAULT_WEIGHTS.placementRate
+  }
+}
+
+// TODO: Allow injecting probability estimates from external models or APIs
+// to further tune the scoring of each horse.


### PR DESCRIPTION
## Summary
- make score weights configurable and document them
- simplify horse ranking calculations
- expose a scoring helper and allow future external data

## Testing
- `npx eslint backend/src/horse/horse-ranking.js`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68877755c1f88330b034295b907257e8