### PR TITLE
Add indicators for favorite start positions

### DIFF
--- a/frontend/src/views/RaceHorses/components/RankedHorsesTable.vue
+++ b/frontend/src/views/RaceHorses/components/RankedHorsesTable.vue
@@ -1,12 +1,51 @@
 <template>
-    <v-data-table :headers="rankedHeaders" :items="rankedHorses" :items-per-page="16" class="elevation-1">
-        <!-- Your v-slot templates here -->
+  <div>
+    <v-data-table
+      :headers="rankedHeaders"
+      :items="rankedHorses"
+      :items-per-page="16"
+      class="elevation-1"
+    >
+      <template v-slot:item.favoriteStartPosition="{ item }">
+        {{ item.favoriteStartPosition }}
+        <span v-if="matchesStartPosition(item)" title="Favorite start position" class="ml-1">Ⓢ</span>
+      </template>
+      <template v-slot:item.favoriteStartMethod="{ item }">
+        {{ item.favoriteStartMethod }}
+        <span v-if="matchesStartMethod(item)" title="Favorite start method" class="ml-1">🏅</span>
+      </template>
     </v-data-table>
+    <div class="mt-2 legend">
+      <span>🏅 – favorite start method for this race</span>
+      <span>Ⓢ – favorite start position this race</span>
+    </div>
+  </div>
 </template>
 
 <script>
 export default {
-    props: ['rankedHorses'],
-    // rankedHeaders and other script data
+  props: {
+    rankedHorses: Array,
+    rankedHeaders: {
+      type: Array,
+      default: () => []
+    },
+    currentRace: Object
+  },
+  methods: {
+    matchesStartPosition(item) {
+      return item.favoriteStartPosition === item.programNumber;
+    },
+    matchesStartMethod(item) {
+      const method = this.currentRace?.startMethod || this.currentRace?.raceType?.text;
+      return item.favoriteStartMethod && method && item.favoriteStartMethod === method;
+    }
+  }
 }
 </script>
+
+<style scoped>
+.legend span {
+  margin-right: 12px;
+}
+</style>


### PR DESCRIPTION
## Summary
- enhance `RankedHorsesTable.vue` with logic for matching the current race
- show symbols when the favorite start method or position matches
- add a legend explaining the symbols

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_688786319a248330863e53026424ca63