### PR TITLE
Add Elo rating calculation

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "start": "node src/index.js",
-    "dev": "nodemon src/index.js"
+    "dev": "nodemon src/index.js",
+    "update-ratings": "node src/horse/update-elo-ratings.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/horse/horse-rating-model.js
+++ b/backend/src/horse/horse-rating-model.js
@@ -1,0 +1,10 @@
+import mongoose from 'mongoose'
+
+const HorseRatingSchema = new mongoose.Schema({
+  horseId: { type: Number, required: true, unique: true },
+  rating: { type: Number, default: 1000 },
+  numberOfRaces: { type: Number, default: 0 },
+  lastUpdated: { type: Date, default: Date.now }
+})
+
+export default mongoose.model('HorseRating', HorseRatingSchema, 'horse_ratings')

--- a/backend/src/horse/rating-meta-model.js
+++ b/backend/src/horse/rating-meta-model.js
@@ -1,0 +1,8 @@
+import mongoose from 'mongoose'
+
+const RatingMetaSchema = new mongoose.Schema({
+  _id: { type: String, default: 'elo' },
+  lastProcessedRaceDate: { type: Date, default: new Date(0) }
+})
+
+export default mongoose.model('RatingMeta', RatingMetaSchema, 'rating_meta')

--- a/backend/src/horse/update-elo-ratings.js
+++ b/backend/src/horse/update-elo-ratings.js
@@ -1,0 +1,137 @@
+import mongoose from 'mongoose'
+import connectDB from '../config/db.js'
+import Horse from './horse-model.js'
+import HorseRating from './horse-rating-model.js'
+import RatingMeta from './rating-meta-model.js'
+
+const DEFAULT_K = 20
+const DEFAULT_DECAY_DAYS = 365
+
+const calculateExpected = (ratingA, ratingB) => {
+  return 1 / (1 + Math.pow(10, (ratingB - ratingA) / 400))
+}
+
+const getRecencyWeight = (date, decayDays = DEFAULT_DECAY_DAYS) => {
+  const diff = Date.now() - new Date(date).getTime()
+  const days = diff / (1000 * 60 * 60 * 24)
+  return Math.exp(-days / decayDays)
+}
+
+const getExperienceMultiplier = (races) => {
+  if (races < 5) return 1.5
+  if (races < 20) return 1.2
+  return 1
+}
+
+const processRace = (horsePlacements, ratings, k, raceDate, decayDays) => {
+  const deltas = {}
+  const ids = Object.keys(horsePlacements)
+  const weight = getRecencyWeight(raceDate, decayDays)
+  for (let i = 0; i < ids.length; i++) {
+    for (let j = i + 1; j < ids.length; j++) {
+      const idA = ids[i]
+      const idB = ids[j]
+      const placeA = horsePlacements[idA]
+      const placeB = horsePlacements[idB]
+      if (placeA == null || placeB == null) continue
+      const entryA = ratings.get(idA) || { rating: 1000, numberOfRaces: 0 }
+      const entryB = ratings.get(idB) || { rating: 1000, numberOfRaces: 0 }
+      const ratingA = entryA.rating
+      const ratingB = entryB.rating
+      let outcomeA = 0.5
+      if (placeA < placeB) outcomeA = 1
+      else if (placeA > placeB) outcomeA = 0
+      const expectedA = calculateExpected(ratingA, ratingB)
+      const expectedB = 1 - expectedA
+      const outcomeB = 1 - outcomeA
+      const factorA = getExperienceMultiplier(entryA.numberOfRaces)
+      const factorB = getExperienceMultiplier(entryB.numberOfRaces)
+      const deltaA = weight * k * factorA * (outcomeA - expectedA)
+      const deltaB = weight * k * factorB * (outcomeB - expectedB)
+      deltas[idA] = (deltas[idA] || 0) + deltaA
+      deltas[idB] = (deltas[idB] || 0) + deltaB
+    }
+  }
+  for (const id of ids) {
+    const base = ratings.get(id) || { rating: 1000, numberOfRaces: 0 }
+    base.rating += deltas[id] || 0
+    base.numberOfRaces += 1
+    ratings.set(id, base)
+  }
+}
+
+const updateRatings = async (k = DEFAULT_K, decayDays = DEFAULT_DECAY_DAYS) => {
+  await connectDB()
+
+  const meta = await RatingMeta.findById('elo')
+  const lastDate = meta?.lastProcessedRaceDate || new Date(0)
+
+  const pipeline = [
+    { $unwind: '$results' },
+    { $project: {
+        horseId: '$id',
+        raceId: '$results.raceInformation.raceId',
+        raceDate: '$results.raceInformation.date',
+        placement: '$results.placement.sortValue',
+        withdrawn: '$results.withdrawn'
+    } },
+    { $match: { withdrawn: { $ne: true }, raceDate: { $gt: lastDate } } },
+    { $group: {
+        _id: '$raceId',
+        raceDate: { $first: '$raceDate' },
+        horses: { $push: { horseId: '$horseId', placement: '$placement' } }
+    } },
+    { $sort: { raceDate: 1 } }
+  ]
+
+  const races = await Horse.aggregate(pipeline)
+
+  const ratings = new Map()
+  const existing = await HorseRating.find().lean()
+  for (const doc of existing) {
+    ratings.set(String(doc.horseId), { rating: doc.rating, numberOfRaces: doc.numberOfRaces })
+  }
+
+  let raceCount = 0
+  for (const race of races) {
+    const placements = {}
+    for (const h of race.horses) {
+      placements[h.horseId] = h.placement
+    }
+    processRace(placements, ratings, k, race.raceDate, decayDays)
+    raceCount++
+  }
+
+  const bulk = HorseRating.collection.initializeUnorderedBulkOp()
+  for (const [horseId, info] of ratings.entries()) {
+    bulk.find({ horseId: Number(horseId) }).upsert().updateOne({
+      $set: {
+        rating: info.rating,
+        numberOfRaces: info.numberOfRaces,
+        lastUpdated: new Date()
+      }
+    })
+  }
+  if (bulk.length > 0) await bulk.execute()
+
+  const lastRaceDate = races.length > 0 ? races[races.length - 1].raceDate : lastDate
+  await RatingMeta.updateOne({ _id: 'elo' }, { lastProcessedRaceDate: lastRaceDate }, { upsert: true })
+
+  await mongoose.disconnect()
+
+  console.log(`Processed ${raceCount} races, updated ${ratings.size} horses`)
+}
+
+if (process.argv[1] === import.meta.url) {
+  const k = process.env.ELO_K ? Number(process.env.ELO_K) : DEFAULT_K
+  const decayDays = process.env.RATING_DECAY_DAYS ? Number(process.env.RATING_DECAY_DAYS) : DEFAULT_DECAY_DAYS
+  updateRatings(k, decayDays).then(() => {
+    console.log('Horse ratings updated')
+    process.exit(0)
+  }).catch(err => {
+    console.error('Failed to update horse ratings', err)
+    process.exit(1)
+  })
+}
+
+export default updateRatings


### PR DESCRIPTION
## Summary
- add a HorseRating mongoose model
- implement update-elo-ratings.js script to compute Elo scores
- expose script via `yarn update-ratings`
- improve script with incremental processing, recency weighting, experience-based K and console logging

## Testing
- `node --check backend/src/horse/update-elo-ratings.js`


------
https://chatgpt.com/codex/tasks/task_e_68878b16e1c48330bbedb2e7336bc02b