### PR TITLE
Add Elo rating history logging

### DIFF
--- a/backend/src/elo/elo-service.js
+++ b/backend/src/elo/elo-service.js
@@ -1,0 +1,80 @@
+import HorseRating from './horse-rating-model.js'
+import RatingHistory from './rating-history-model.js'
+
+const DEFAULT_RATING = 1500
+const K_FACTOR = 32
+
+const updateRatingsForRace = async (raceId, raceData) => {
+  if (!raceData || !Array.isArray(raceData.horses)) {
+    throw new Error('Invalid race data')
+  }
+
+  const horses = raceData.horses.map(h => ({ id: h.id, placement: h.placement }))
+  const horseIds = horses.map(h => h.id)
+  const existing = await HorseRating.find({ horseId: { $in: horseIds } })
+  const ratingMap = new Map()
+  existing.forEach(r => ratingMap.set(r.horseId, r))
+
+  for (const horse of horses) {
+    if (!ratingMap.has(horse.id)) {
+      ratingMap.set(horse.id, new HorseRating({ horseId: horse.id, rating: DEFAULT_RATING }))
+    }
+  }
+
+  const currentRatings = {}
+  for (const horse of horses) {
+    currentRatings[horse.id] = ratingMap.get(horse.id).rating
+  }
+
+  const n = horses.length
+  const history = []
+  for (const horse of horses) {
+    let actual = 0
+    let expected = 0
+    for (const opponent of horses) {
+      if (horse.id === opponent.id) continue
+      const r1 = currentRatings[horse.id]
+      const r2 = currentRatings[opponent.id]
+      const exp = 1 / (1 + Math.pow(10, (r2 - r1) / 400))
+      expected += exp
+      if (horse.placement < opponent.placement) actual += 1
+      else if (horse.placement === opponent.placement) actual += 0.5
+    }
+    expected /= (n - 1)
+    actual /= (n - 1)
+    const ratingChange = K_FACTOR * (actual - expected)
+    const entry = ratingMap.get(horse.id)
+    const oldRating = entry.rating
+    entry.rating = Math.round(entry.rating + ratingChange)
+    entry.numberOfRaces += 1
+    entry.lastUpdated = new Date()
+
+    history.push({
+      raceId,
+      timestamp: entry.lastUpdated,
+      horseId: horse.id,
+      oldRating,
+      newRating: entry.rating
+    })
+  }
+
+  const promises = []
+  for (const entry of ratingMap.values()) {
+    const { horseId, rating, numberOfRaces, lastUpdated } = entry
+    promises.push(
+      HorseRating.findOneAndUpdate(
+        { horseId },
+        { rating, numberOfRaces, lastUpdated },
+        { upsert: true, new: true }
+      )
+    )
+  }
+
+  const updated = await Promise.all(promises)
+  await RatingHistory.insertMany(history)
+  return updated
+}
+
+export default {
+  updateRatingsForRace
+}

--- a/backend/src/elo/horse-rating-model.js
+++ b/backend/src/elo/horse-rating-model.js
@@ -1,0 +1,10 @@
+import mongoose from 'mongoose'
+
+const HorseRatingSchema = new mongoose.Schema({
+  horseId: { type: Number, required: true, unique: true },
+  rating: { type: Number, default: 1500 },
+  numberOfRaces: { type: Number, default: 0 },
+  lastUpdated: { type: Date, default: Date.now }
+})
+
+export default mongoose.model('HorseRating', HorseRatingSchema)

--- a/backend/src/elo/rating-history-model.js
+++ b/backend/src/elo/rating-history-model.js
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose'
+
+const RatingHistorySchema = new mongoose.Schema({
+  raceId: { type: Number, required: true },
+  timestamp: { type: Date, default: Date.now },
+  horseId: { type: Number, required: true },
+  oldRating: { type: Number, required: true },
+  newRating: { type: Number, required: true }
+})
+
+export default mongoose.model('RatingHistory', RatingHistorySchema)

--- a/backend/src/race/race-routes.js
+++ b/backend/src/race/race-routes.js
@@ -1,5 +1,6 @@
 import express from 'express'
 import raceService from './race-service.js'
+import eloService from '../elo/elo-service.js'
 import { validateNumericParam } from '../middleware/validators.js'
 
 const router = express.Router()
@@ -18,6 +19,21 @@ router.get('/:id', validateNumericParam('id'), async (req, res) => {
     } catch (error) {
         console.error(`Error fetching race with ID ${req.params.id}:`, error)
         res.status(500).send('Failed to fetch race. Please try again.')
+    }
+})
+
+// Update Elo ratings for a race
+router.post('/:id/results', validateNumericParam('id'), async (req, res) => {
+    try {
+        const raceData = req.body
+        if (!raceData || !Array.isArray(raceData.horses)) {
+            return res.status(400).send('Invalid race data')
+        }
+        const updated = await eloService.updateRatingsForRace(req.params.id, raceData)
+        res.json(updated)
+    } catch (error) {
+        console.error(`Error updating ratings for race ${req.params.id}:`, error)
+        res.status(500).send('Failed to update ratings')
     }
 })
 


### PR DESCRIPTION
## Summary
- add RatingHistory mongoose model for audit trail
- record rating changes in `updateRatingsForRace`
- send raceId to Elo service when posting race results

## Testing
- `npx eslint src/elo/elo-service.js src/elo/horse-rating-model.js src/elo/rating-history-model.js src/race/race-routes.js` *(fails: ESLint couldn't find config 'standard')*

------
https://chatgpt.com/codex/tasks/task_e_68878b17b7c083309bd04298dd4e7f3d