### PR TITLE
Implement automatic horse rating updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,14 @@ yarn build
 
 The compiled static files will be in `frontend/dist` and can be served by any static file server.
 
+## Scheduled Ratings Update
+
+The back‑end runs a cron job that refreshes horse ratings every hour. It looks for
+records in the `HorseRating` collection where `lastUpdated` is more than 24 hours
+old. For each outdated entry it fetches recent race results and updates the
+rating using `updateRatingsForRace`.
+
+The job starts automatically when the Express server launches but the exported
+`startRatingsCronJob` function can also be invoked from another process if you
+prefer running it separately.
+

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,8 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
-    "mongoose": "^8.0.3"
+    "mongoose": "^8.0.3",
+    "node-cron": "^3.0.2"
   },
   "devDependencies": {
     "eslint": "^9.0.0",

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -7,6 +7,7 @@ import connectDB from './config/db.js'
 import horseRoutes from './horse/horse-routes.js'
 import racedayRoutes from './raceday/raceday-routes.js'
 import raceRoutes from './race/race-routes.js'
+import { startRatingsCronJob } from './rating/ratings-scheduler.js'
 
 // Middleware
 import errorHandler from './middleware/errorHandler.js'
@@ -18,6 +19,7 @@ const PORT = process.env.PORT || 3001
 
 app.use(express.json({ limit: '2mb' }));
 connectDB()
+startRatingsCronJob()
 
 app.use(cors())
 app.get('/', (req, res) => {

--- a/backend/src/rating/horseRating-model.js
+++ b/backend/src/rating/horseRating-model.js
@@ -1,0 +1,9 @@
+import mongoose from 'mongoose'
+
+const HorseRatingSchema = new mongoose.Schema({
+    horseId: { type: Number, required: true, unique: true },
+    rating: { type: Number, default: 0 },
+    lastUpdated: { type: Date, default: Date.now }
+})
+
+export default mongoose.model('HorseRating', HorseRatingSchema)

--- a/backend/src/rating/rating-service.js
+++ b/backend/src/rating/rating-service.js
@@ -1,0 +1,35 @@
+import axios from 'axios'
+import HorseRating from './horseRating-model.js'
+
+const fetchResults = async horseId => {
+    const url = `https://api.travsport.se/webapi/horses/results/organisation/TROT/sourceofdata/SPORT/horseid/${horseId}`
+    const { data } = await axios.get(url)
+    return data
+}
+
+const calculateRatingChange = result => {
+    const place = result.placement?.sortValue
+    if (place === 1) return 5
+    if (place === 2) return 3
+    if (place === 3) return 1
+    return 0
+}
+
+export const updateRatingsForRace = async (horseId, result) => {
+    const change = calculateRatingChange(result)
+    await HorseRating.updateOne({ horseId }, {
+        $inc: { rating: change },
+        $setOnInsert: { lastUpdated: new Date() }
+    }, { upsert: true })
+}
+
+export const refreshHorseRating = async horseRating => {
+    const results = await fetchResults(horseRating.horseId)
+    const last = horseRating.lastUpdated || new Date(0)
+    const newResults = results.filter(r => new Date(r.raceInformation.date) > last)
+    for (const res of newResults) {
+        await updateRatingsForRace(horseRating.horseId, res)
+    }
+    horseRating.lastUpdated = new Date()
+    await horseRating.save()
+}

--- a/backend/src/rating/ratings-scheduler.js
+++ b/backend/src/rating/ratings-scheduler.js
@@ -1,0 +1,17 @@
+import cron from 'node-cron'
+import HorseRating from './horseRating-model.js'
+import { refreshHorseRating } from './rating-service.js'
+
+export const startRatingsCronJob = () => {
+    cron.schedule('0 * * * *', async () => {
+        const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000)
+        const outdated = await HorseRating.find({ lastUpdated: { $lt: cutoff } })
+        for (const hr of outdated) {
+            try {
+                await refreshHorseRating(hr)
+            } catch (err) {
+                console.error('Rating refresh failed for horseId', hr.horseId, err)
+            }
+        }
+    })
+}


### PR DESCRIPTION
## Summary
- add `HorseRating` model and rating service
- schedule hourly cron job to refresh outdated ratings
- start the job from the Express server
- document the new job in README

## Testing
- `node backend/src/index.js`

------
https://chatgpt.com/codex/tasks/task_e_68878b18a6ec8330bb260058be5c69b8