### PR TITLE
Move ratings update to admin page

### DIFF
--- a/frontend/src/components/NavigationBar.vue
+++ b/frontend/src/components/NavigationBar.vue
@@ -4,6 +4,7 @@
         <v-toolbar-title>Navbar</v-toolbar-title>
         <v-spacer></v-spacer>
         <v-btn to="/" text>Home</v-btn>
+        <v-btn to="/admin" text>Admin</v-btn>
     </v-app-bar>
 </template>
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -3,6 +3,7 @@ import RacedayInputView from '@/views/RacedayInput/RacedayInputView.vue'
 import RacedayView from '@/views/Raceday/RacedayView.vue'
 import RaceHorsesView from '@/views/RaceHorses/RaceHorsesView.vue'
 import DevRatingsView from '@/views/DevRatingsView.vue'
+import AdminView from '@/views/Admin/AdminView.vue'
 
 const routes = [
   {
@@ -32,6 +33,11 @@ const routes = [
     path: '/dev/ratings',
     name: 'DevRatings',
     component: DevRatingsView
+  },
+  {
+    path: '/admin',
+    name: 'Admin',
+    component: AdminView
   }
 ]
 

--- a/frontend/src/views/Admin/AdminView.vue
+++ b/frontend/src/views/Admin/AdminView.vue
@@ -1,0 +1,36 @@
+<template>
+  <v-container class="pt-12">
+    <v-row>
+      <v-col>
+        <h1>Admin</h1>
+        <v-btn color="primary" @click="updateRatings">Update Ratings</v-btn>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+import AdminService from './services/AdminService.js'
+
+export default {
+  name: 'AdminView',
+  setup() {
+    const updateRatings = async () => {
+      try {
+        await AdminService.triggerRatingsUpdate()
+      } catch (error) {
+        console.error('Manual rating update failed', error)
+      }
+    }
+    return {
+      updateRatings
+    }
+  }
+}
+</script>
+
+<style scoped>
+.pt-12 {
+  padding-top: 70px;
+}
+</style>

--- a/frontend/src/views/Admin/services/AdminService.js
+++ b/frontend/src/views/Admin/services/AdminService.js
@@ -1,0 +1,14 @@
+import axios from 'axios'
+
+const triggerRatingsUpdate = async () => {
+  try {
+    await axios.post(`${import.meta.env.VITE_BE_URL}/api/elo/update`)
+  } catch (error) {
+    console.error('Failed to trigger ratings update', error)
+    throw error
+  }
+}
+
+export default {
+  triggerRatingsUpdate
+}

--- a/frontend/src/views/RaceHorses/RaceHorsesView.vue
+++ b/frontend/src/views/RaceHorses/RaceHorsesView.vue
@@ -3,7 +3,6 @@
         <v-row>
             <v-col>
                 <button @click="navigateToRaceDay(raceDayId)">Go to Race Day</button>
-                <button class="ml-4" @click="manualUpdateRatings">Update Ratings</button>
             </v-col>
         </v-row>
         <v-row>
@@ -64,8 +63,7 @@ import { useStore } from 'vuex'
 import {
     checkIfUpdatedRecently,
     fetchRaceFromRaceId,
-    fetchHorseScores,
-    triggerRatingsUpdate
+    fetchHorseScores
 } from '@/views/RaceHorses/services/RaceHorsesService.js'
 import RacedayService from '@/views/Raceday/services/RacedayService.js'
 
@@ -99,13 +97,6 @@ export default {
             router.push(`/raceday/${raceDayId}`)
         }
 
-        const manualUpdateRatings = async () => {
-            try {
-                await triggerRatingsUpdate()
-            } catch (error) {
-                console.error('Manual rating update failed', error)
-            }
-        }
         const currentRace = computed(() => store.state.raceHorses.currentRace)
         const rankedHorses = computed(() => store.getters['raceHorses/getRankedHorses'])
         const rankHorses = async () => {
@@ -297,7 +288,6 @@ export default {
             racedayTrackName,
             racedayTrackCode,
             navigateToRaceDay,
-            manualUpdateRatings,
             currentRace,
             allHorsesUpdated,
             items,


### PR DESCRIPTION
## Summary
- add an Admin view with a button that triggers the ratings refresh
- link the new view from the navigation bar
- register an `/admin` route
- remove the race-specific "Update Ratings" button

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6888b8e131188330b85ac31e3c79f2a8