### PR TITLE
Add shared Elo engine

### DIFF
--- a/backend/src/driver/update-driver-elo-ratings.js
+++ b/backend/src/driver/update-driver-elo-ratings.js
@@ -2,9 +2,11 @@ import mongoose from 'mongoose'
 import { fileURLToPath } from 'url'
 import connectDB from '../config/db.js'
 import Driver from './driver-model.js'
-import { expectedScore } from '../rating/elo-utils.js'
+import {
+  processRace,
+  DEFAULT_K
+} from '../rating/elo-engine.js'
 
-const DEFAULT_K = 20
 const DEFAULT_RATING = 1400
 const MIN_RACES = 5
 
@@ -14,39 +16,6 @@ const ensureConnection = async () => {
   }
 }
 
-const processRace = (placements, ratings, k) => {
-  const ids = Object.keys(placements)
-  const deltas = {}
-  for (let i = 0; i < ids.length; i++) {
-    for (let j = i + 1; j < ids.length; j++) {
-      const idA = ids[i]
-      const idB = ids[j]
-      const placeA = placements[idA]
-      const placeB = placements[idB]
-      if (placeA == null || placeB == null) continue
-      const entryA = ratings.get(idA) || { rating: DEFAULT_RATING, races: 0 }
-      const entryB = ratings.get(idB) || { rating: DEFAULT_RATING, races: 0 }
-      const ratingA = entryA.rating
-      const ratingB = entryB.rating
-      let outcomeA = 0.5
-      if (placeA < placeB) outcomeA = 1
-      else if (placeA > placeB) outcomeA = 0
-      const expectedA = expectedScore(ratingA, ratingB)
-      const expectedB = 1 - expectedA
-      const outcomeB = 1 - outcomeA
-      const deltaA = k * (outcomeA - expectedA)
-      const deltaB = k * (outcomeB - expectedB)
-      deltas[idA] = (deltas[idA] || 0) + deltaA
-      deltas[idB] = (deltas[idB] || 0) + deltaB
-    }
-  }
-  for (const id of ids) {
-    const base = ratings.get(id) || { rating: DEFAULT_RATING, races: 0 }
-    base.rating += deltas[id] || 0
-    base.races += 1
-    ratings.set(id, base)
-  }
-}
 
 const updateDriverEloRatings = async (k = DEFAULT_K, { disconnect = false } = {}) => {
   await ensureConnection()
@@ -78,7 +47,11 @@ const updateDriverEloRatings = async (k = DEFAULT_K, { disconnect = false } = {}
   const ratings = new Map()
 
   for (const race of raceList) {
-    processRace(race.placements, ratings, k)
+    processRace(race.placements, ratings, {
+      k,
+      defaultRating: DEFAULT_RATING,
+      raceDate: race.date
+    })
   }
 
   const bulk = Driver.collection.initializeUnorderedBulkOp()

--- a/backend/src/rating/elo-engine.js
+++ b/backend/src/rating/elo-engine.js
@@ -1,0 +1,72 @@
+import { expectedScore } from './elo-utils.js'
+
+export const DEFAULT_K = 20
+export const DEFAULT_RATING = 1000
+export const DEFAULT_DECAY_DAYS = 365
+
+export const getRecencyWeight = (date, decayDays = DEFAULT_DECAY_DAYS) => {
+  const diff = Date.now() - new Date(date).getTime()
+  const days = diff / (1000 * 60 * 60 * 24)
+  return Math.exp(-days / decayDays)
+}
+
+export const getExperienceMultiplier = (races) => {
+  if (races < 5) return 1.5
+  if (races < 20) return 1.2
+  return 1
+}
+
+export const processRace = (
+  placements,
+  ratings,
+  {
+    k = DEFAULT_K,
+    defaultRating = DEFAULT_RATING,
+    raceDate = new Date(),
+    decayDays = DEFAULT_DECAY_DAYS
+  } = {}
+) => {
+  const ids = Object.keys(placements)
+  const deltas = {}
+  const weight = getRecencyWeight(raceDate, decayDays)
+  for (let i = 0; i < ids.length; i++) {
+    for (let j = i + 1; j < ids.length; j++) {
+      const idA = ids[i]
+      const idB = ids[j]
+      const placeA = placements[idA]
+      const placeB = placements[idB]
+      if (placeA == null || placeB == null) continue
+      const entryA = ratings.get(idA) || { rating: defaultRating, numberOfRaces: 0 }
+      const entryB = ratings.get(idB) || { rating: defaultRating, numberOfRaces: 0 }
+      const ratingA = entryA.rating
+      const ratingB = entryB.rating
+      let outcomeA = 0.5
+      if (placeA < placeB) outcomeA = 1
+      else if (placeA > placeB) outcomeA = 0
+      const expectedA = expectedScore(ratingA, ratingB)
+      const expectedB = 1 - expectedA
+      const outcomeB = 1 - outcomeA
+      const factorA = getExperienceMultiplier(entryA.numberOfRaces)
+      const factorB = getExperienceMultiplier(entryB.numberOfRaces)
+      const deltaA = weight * k * factorA * (outcomeA - expectedA)
+      const deltaB = weight * k * factorB * (outcomeB - expectedB)
+      deltas[idA] = (deltas[idA] || 0) + deltaA
+      deltas[idB] = (deltas[idB] || 0) + deltaB
+    }
+  }
+  for (const id of ids) {
+    const base = ratings.get(id) || { rating: defaultRating, numberOfRaces: 0 }
+    base.rating += deltas[id] || 0
+    base.numberOfRaces += 1
+    ratings.set(id, base)
+  }
+}
+
+export default {
+  processRace,
+  getRecencyWeight,
+  getExperienceMultiplier,
+  DEFAULT_K,
+  DEFAULT_RATING,
+  DEFAULT_DECAY_DAYS
+}


### PR DESCRIPTION
## Summary
- implement shared rating engine with recency and experience weight
- use new engine in horse and driver rating scripts

## Testing
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6889e5102c2083309c15d1679b42e39e