### PR TITLE
Improve driver Elo realism

### DIFF
--- a/backend/src/driver/update-driver-elo-ratings.js
+++ b/backend/src/driver/update-driver-elo-ratings.js
@@ -7,7 +7,9 @@ import {
   DEFAULT_K
 } from '../rating/elo-engine.js'
 
-const DEFAULT_RATING = 1400
+// Starting rating for all drivers. Lower to allow meaningful drop for
+// poor performers and more realistic distribution.
+const DEFAULT_RATING = 900
 const DEFAULT_DECAY_DAYS = 365
 const MIN_RACES = 5
 
@@ -69,15 +71,50 @@ const updateDriverEloRatings = async (
       raceDate: race.date,
       decayDays
     })
+
+    // Apply extra penalty for new drivers consistently finishing
+    // in the bottom 20% of the field.
+    const totalDrivers = Object.keys(race.placements).length
+    const bottomThreshold = Math.ceil(totalDrivers * 0.8)
+    for (const [driverId, placement] of Object.entries(race.placements)) {
+      const entry = ratings.get(String(driverId)) || {
+        rating: DEFAULT_RATING,
+        numberOfRaces: 0
+      }
+      if (entry.numberOfRaces <= MIN_RACES && placement >= bottomThreshold) {
+        entry.rating -= 15
+        ratings.set(String(driverId), entry)
+      }
+    }
   }
 
   const bulk = Driver.collection.initializeUnorderedBulkOp()
+  const updatedRatings = []
   for (const driverId of seenDrivers) {
-    const info = ratings.get(String(driverId)) || { rating: DEFAULT_RATING, races: 0 }
-    const elo = info.races < MIN_RACES ? DEFAULT_RATING : Math.round(info.rating)
+    const info = ratings.get(String(driverId)) || {
+      rating: DEFAULT_RATING,
+      numberOfRaces: 0
+    }
+    const elo = Math.round(info.rating)
+    updatedRatings.push(elo)
     bulk.find({ _id: driverId }).updateOne({ $set: { elo } })
   }
   if (bulk.length > 0) await bulk.execute()
+
+  // Fetch ratings to log distribution statistics
+  const allDrivers = await Driver.find({}, { elo: 1 }).lean()
+  const allRatings = allDrivers.map(d => d.elo).sort((a, b) => a - b)
+  const minRating = allRatings[0] ?? 0
+  const maxRating = allRatings[allRatings.length - 1] ?? 0
+  const mid = Math.floor(allRatings.length / 2)
+  const medianRating =
+    allRatings.length % 2 === 0
+      ? (allRatings[mid - 1] + allRatings[mid]) / 2
+      : allRatings[mid]
+
+  console.log(
+    `Rating distribution - min: ${minRating}, max: ${maxRating}, median: ${medianRating}`
+  )
 
   if (disconnect && mongoose.connection.readyState !== 0) {
     await mongoose.disconnect()


### PR DESCRIPTION
## Summary
- lower default driver rating
- penalize new drivers that consistently finish at the bottom of a race
- remove provisional protection and always store calculated rating
- log rating distribution stats after updates

## Testing
- `npm test` *(fails: could not find package.json)*
- `npm --prefix backend test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688a267df4688330933bd8c155b83a9b