### PR TITLE
Handle race prize from propTexts

### DIFF
--- a/frontend/src/views/race/RaceHorsesView.vue
+++ b/frontend/src/views/race/RaceHorsesView.vue
@@ -107,8 +107,12 @@ export default {
 
         const displayPrizeMoney = computed(() => {
           const prize = currentRace.value?.totalPrizeMoney;
-          if (typeof prize === 'number') {
+          if (typeof prize === 'number' && prize > 0) {
             return `${prize.toLocaleString('sv-SE')} kr`;
+          }
+          const prizeObj = currentRace.value?.propTexts?.find(pt => pt.typ === 'P');
+          if (prizeObj?.text) {
+            return prizeObj.text.replace(/\./g, ' ');
           }
           return 'N/A';
         });


### PR DESCRIPTION
## Summary
- improve prize money display logic to fall back to propTexts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688a63edd0c4833081e6b9cdc89ff38a