### PR TITLE
Add tracks metadata collection

### DIFF
--- a/backend/src/track/track-model.js
+++ b/backend/src/track/track-model.js
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose'
+
+const TrackSchema = new mongoose.Schema({
+  trackCode: { type: String, required: true, unique: true },
+  trackName: { type: String, required: true },
+  trackLength: { type: Number, required: true },
+  trackRecord: { type: String },
+  favouriteStartingPosition: { type: Number }
+})
+
+export default mongoose.model('Track', TrackSchema, 'tracks')

--- a/backend/src/track/track-service.js
+++ b/backend/src/track/track-service.js
@@ -1,0 +1,9 @@
+import Track from './track-model.js'
+
+const getTrackByCode = async (trackCode) => {
+  return await Track.findOne({ trackCode }).lean()
+}
+
+export default {
+  getTrackByCode
+}

--- a/scripts/seed-track-metadata.js
+++ b/scripts/seed-track-metadata.js
@@ -1,0 +1,52 @@
+import mongoose from 'mongoose'
+import { fileURLToPath } from 'url'
+import connectDB from '../backend/src/config/db.js'
+import Track from '../backend/src/track/track-model.js'
+
+const ensureConnection = async () => {
+  if (mongoose.connection.readyState === 0) {
+    await connectDB()
+  }
+}
+
+const tracks = [
+  {
+    trackCode: 'S',
+    trackName: 'Solvalla',
+    trackLength: 1000,
+    trackRecord: '1.09,9',
+    favouriteStartingPosition: 5
+  },
+  {
+    trackCode: 'Å',
+    trackName: 'Åby',
+    trackLength: 1000
+  },
+  {
+    trackCode: 'B',
+    trackName: 'Bergsåker',
+    trackLength: 1000
+  }
+]
+
+const seedTrackMetadata = async ({ disconnect = false } = {}) => {
+  await ensureConnection()
+  await Track.deleteMany({})
+  await Track.insertMany(tracks)
+  if (disconnect && mongoose.connection.readyState !== 0) {
+    await mongoose.disconnect()
+  }
+  console.log(`Seeded ${tracks.length} tracks`)
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  seedTrackMetadata({ disconnect: true }).then(() => {
+    console.log('Track metadata seeded')
+    process.exit(0)
+  }).catch(err => {
+    console.error('Failed to seed tracks', err)
+    process.exit(1)
+  })
+}
+
+export default seedTrackMetadata


### PR DESCRIPTION
## Summary
- model Track entity in backend
- expose `TrackService.getTrackByCode`
- create seeding script with some sample tracks

## Testing
- `npm test --prefix backend` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_688a6c3fa9bc833085e10ba3247cec84