### PR TITLE
Add track metadata in startlist view

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -7,6 +7,7 @@ import connectDB from './config/db.js'
 import horseRoutes from './horse/horse-routes.js'
 import racedayRoutes from './raceday/raceday-routes.js'
 import raceRoutes from './race/race-routes.js'
+import trackRoutes from './track/track-routes.js'
 import eloRoutes from './rating/elo-routes.js'
 import { startRatingsCronJob } from './rating/ratings-scheduler.js'
 import { startDriverCronJob } from './driver/scheduler.js'
@@ -32,6 +33,7 @@ app.get('/', (req, res) => {
 app.use('/api/horses', horseRoutes)
 app.use('/api/raceday', racedayRoutes)
 app.use('/api/race', raceRoutes)
+app.use('/api/track', trackRoutes)
 app.use('/api/rating', eloRoutes)
 
 // 404 handler

--- a/backend/src/track/track-routes.js
+++ b/backend/src/track/track-routes.js
@@ -1,0 +1,21 @@
+import express from 'express'
+import trackService from './track-service.js'
+
+const router = express.Router()
+
+// Get track metadata by track code
+router.get('/:trackCode', async (req, res) => {
+  try {
+    const trackCode = req.params.trackCode
+    const track = await trackService.getTrackByCode(trackCode)
+    if (!track) {
+      return res.status(404).send('Track not found.')
+    }
+    res.json(track)
+  } catch (error) {
+    console.error(`Error fetching track with code ${req.params.trackCode}:`, error)
+    res.status(500).send('Failed to fetch track')
+  }
+})
+
+export default router

--- a/frontend/src/views/race/RaceHorsesView.vue
+++ b/frontend/src/views/race/RaceHorsesView.vue
@@ -14,6 +14,9 @@
             <div class="race-meta text-subtitle-1">
               {{ raceMetaString }}
             </div>
+            <div class="track-meta text-subtitle-2">
+              {{ trackMetaString }}
+            </div>
           </v-col>
         </v-row>
         <v-row>
@@ -66,6 +69,7 @@ import {
     triggerRatingsUpdate
 } from '@/views/race/services/RaceHorsesService.js'
 import RacedayService from '@/views/raceday/services/RacedayService.js'
+import TrackService from '@/views/race/services/TrackService.js'
 
 export default {
     name: 'RaceHorsesView',
@@ -120,6 +124,25 @@ export default {
         const raceMetaString = computed(() => {
           return `Start: ${displayStartMethod.value} | Distance: ${displayDistance.value} | Type: ${displayRaceType.value} | Prize: ${displayPrizeMoney.value}`;
         });
+
+        const displayTrackLength = computed(() => {
+          const len = trackMeta.value?.trackLength
+          return typeof len === 'number' ? `${len} m` : 'N/A'
+        });
+
+        const displayTrackRecord = computed(() => {
+          return trackMeta.value?.trackRecord || 'N/A'
+        });
+
+        const displayFavStartPos = computed(() => {
+          const pos = trackMeta.value?.favouriteStartingPosition
+          return typeof pos === 'number' ? pos : 'N/A'
+        });
+
+        const trackMetaString = computed(() => {
+          const name = getTrackName(racedayTrackCode.value)
+          return `Track: ${name} | Length: ${displayTrackLength.value} | Fav. pos: ${displayFavStartPos.value} | Record: ${displayTrackRecord.value}`
+        });
         const store = useStore()
         const route = useRoute()
         const router = useRouter()
@@ -147,6 +170,7 @@ export default {
         const updatedHorses = ref([]) // A list to store IDs of updated horses
         const racedayTrackName = ref('')
         const racedayTrackCode = ref('')
+        const trackMeta = ref({})
 
         const getTrackCodeFromName = (name) => {
             for (const [code, n] of Object.entries(trackNames)) {
@@ -170,6 +194,17 @@ export default {
             } else if (currentRace.value.trackCode) {
                 racedayTrackCode.value = currentRace.value.trackCode
                 racedayTrackName.value = getTrackName(currentRace.value.trackCode)
+            }
+
+            if (racedayTrackCode.value) {
+                try {
+                    trackMeta.value = await TrackService.getTrackByCode(racedayTrackCode.value) || {}
+                } catch (error) {
+                    console.error('Failed to fetch track metadata:', error)
+                    trackMeta.value = {}
+                }
+            } else {
+                trackMeta.value = {}
             }
         }
 
@@ -330,6 +365,7 @@ export default {
             raceStartMethod,
             raceStartMethodCode,
             raceMetaString,
+            trackMetaString,
         }
     },
 }
@@ -343,5 +379,9 @@ export default {
 .race-meta {
     margin-top: 4px;
     margin-bottom: 8px;
+}
+
+.track-meta {
+    margin-bottom: 12px;
 }
 </style>

--- a/frontend/src/views/race/services/TrackService.js
+++ b/frontend/src/views/race/services/TrackService.js
@@ -1,0 +1,15 @@
+import axios from 'axios'
+
+const getTrackByCode = async (trackCode) => {
+  try {
+    const response = await axios.get(`${import.meta.env.VITE_BE_URL}/api/track/${trackCode}`)
+    return response.data
+  } catch (error) {
+    console.error(`Failed to fetch track with code ${trackCode}:`, error)
+    throw error
+  }
+}
+
+export default {
+  getTrackByCode
+}


### PR DESCRIPTION
## Summary
- expose `/api/track/:trackCode` endpoint
- fetch track metadata from the backend in `RaceHorsesView`
- display track length, record and favourite start position

## Testing
- `yarn install`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_688a6f906f008330a723157ce9694809