### PR TITLE
Display horse and driver Elo ratings on Start List

### DIFF
--- a/backend/src/driver/driver-routes.js
+++ b/backend/src/driver/driver-routes.js
@@ -1,0 +1,18 @@
+import express from 'express'
+import Driver from './driver-model.js'
+
+const router = express.Router()
+
+router.get('/ratings', async (req, res) => {
+  try {
+    const ids = req.query.ids ? req.query.ids.split(',').map(id => parseInt(id)) : []
+    const query = ids.length ? { _id: { $in: ids } } : {}
+    const drivers = await Driver.find(query, '_id elo').lean()
+    res.json(drivers.map(d => ({ id: d._id, elo: d.elo })))
+  } catch (error) {
+    console.error('Error fetching driver elo ratings:', error)
+    res.status(500).send('Failed to fetch driver ratings.')
+  }
+})
+
+export default router

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -9,6 +9,7 @@ import racedayRoutes from './raceday/raceday-routes.js'
 import raceRoutes from './race/race-routes.js'
 import trackRoutes from './track/track-routes.js'
 import eloRoutes from './rating/elo-routes.js'
+import driverRoutes from './driver/driver-routes.js'
 import { startRatingsCronJob } from './rating/ratings-scheduler.js'
 import { startDriverCronJob } from './driver/scheduler.js'
 
@@ -35,6 +36,7 @@ app.use('/api/raceday', racedayRoutes)
 app.use('/api/race', raceRoutes)
 app.use('/api/track', trackRoutes)
 app.use('/api/rating', eloRoutes)
+app.use('/api/driver', driverRoutes)
 
 // 404 handler
 app.use((req, res) => {

--- a/frontend/src/views/race/services/RaceHorsesService.js
+++ b/frontend/src/views/race/services/RaceHorsesService.js
@@ -85,6 +85,17 @@ const fetchHorseScores = async (ids = []) => {
     }
 }
 
+const fetchDriverRatings = async (ids = []) => {
+    try {
+        const params = ids.length ? { params: { ids: ids.join(',') } } : {}
+        const response = await axios.get(`${import.meta.env.VITE_BE_URL}/api/driver/ratings`, params)
+        return response.data
+    } catch (error) {
+        console.error('Failed to fetch driver ratings', error)
+        throw error
+    }
+}
+
 const triggerRatingsUpdate = async () => {
     try {
         await axios.post(`${import.meta.env.VITE_BE_URL}/api/rating/update`)
@@ -101,5 +112,6 @@ export {
     fetchHorseRankings,
     setEarliestUpdatedHorseTimestamp,
     fetchHorseScores,
+    fetchDriverRatings,
     triggerRatingsUpdate
 }


### PR DESCRIPTION
## Summary
- expose driver Elo ratings via new `/api/driver/ratings` endpoint
- load driver ratings alongside horse scores and enrich race horses with `eloRating` and `driverEloRating`
- show Horse Elo and Driver Elo columns in Start List with rounded values

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688b0af5a6448330adbba42ec1530a52