### PR TITLE
Populate horse update timestamps during raceday import

### DIFF
--- a/backend/src/raceday/raceday-service.js
+++ b/backend/src/raceday/raceday-service.js
@@ -81,6 +81,18 @@ const updateHorsesForRaceday = async (raceDay) => {
             await delay(400)
         }
     }
+
+    // After all horses have been refreshed, align race metadata so the UI
+    // can display when horses were last updated. This mirrors the manual
+    // update flow where this timestamp is calculated after updating each
+    // horse individually.
+    for (const race of raceDay.raceList) {
+        try {
+            await updateEarliestUpdatedHorseTimestamp(raceDay._id, race.raceId)
+        } catch (err) {
+            console.error(`Failed updating earliest horse timestamp for race ${race.raceId}:`, err.message)
+        }
+    }
 }
 
 const getAllRacedays = async (skip = 0, limit = null) => {


### PR DESCRIPTION
## Summary
- ensure raceday imports update race metadata after horse refreshes
- mirror manual race updates by computing earliest horse update timestamps for every race

## Testing
- `cd backend && npm test` (fails: Missing script: "test")


------
https://chatgpt.com/codex/tasks/task_e_688b0df84c648330b0b98d97d5a7eaa9