### PR TITLE
Fix driver elo display in RaceHorsesView

### DIFF
--- a/frontend/src/views/race/RaceHorsesView.vue
+++ b/frontend/src/views/race/RaceHorsesView.vue
@@ -37,8 +37,8 @@
                             <template v-slot:item.eloRating="{ item }">
                                 {{ formatElo(item.columns.eloRating) }}
                             </template>
-                            <template v-slot:item["driver.elo"]="{ item }">
-                                {{ formatElo(item.columns['driver.elo']) }}
+                            <template v-slot:item.driverElo="{ item }">
+                                {{ formatElo(item.columns.driverElo) }}
                             </template>
                         </v-data-table>
                     </v-window-item>
@@ -250,6 +250,7 @@ export default {
                         score: scoreMap[h.id],
                         rating: ratingMap[h.id],
                         eloRating: ratingMap[h.id],
+                        driverElo,
                         driver: {
                             ...h.driver,
                             id: driverId,
@@ -307,7 +308,7 @@ export default {
             { title: 'Horse Name', key: 'name' },
             { title: 'Driver Name', key: 'driver.name' },
             { title: 'Horse Elo', key: 'eloRating' },
-            { title: 'Driver Elo', key: 'driver.elo' },
+            { title: 'Driver Elo', key: 'driverElo' },
             { key: 'horseWithdrawn' },
         ]
 


### PR DESCRIPTION
## Summary
- expose driver elo rating as `driverElo` on horse objects
- show driver elo in Start List using `v-slot:item.driverElo`
- update headers to reference `driverElo`

## Testing
- `yarn --cwd frontend install`
- `yarn --cwd frontend build`


------
https://chatgpt.com/codex/tasks/task_e_688b27f096ac8330a1546c75bb5d5014