### PR TITLE
Display ATG betting games across races

### DIFF
--- a/backend/src/game/game-routes.js
+++ b/backend/src/game/game-routes.js
@@ -1,0 +1,17 @@
+import express from 'express'
+import { validateObjectIdParam } from '../middleware/validators.js'
+import gameService from './game-service.js'
+
+const router = express.Router()
+
+router.get('/:racedayId', validateObjectIdParam('racedayId'), async (req, res) => {
+  try {
+    const data = await gameService.mapGamesForRaceday(req.params.racedayId)
+    res.json(data)
+  } catch (err) {
+    console.error('Error fetching game types:', err)
+    res.status(500).send('Failed to fetch spelformer')
+  }
+})
+
+export default router

--- a/backend/src/game/game-service.js
+++ b/backend/src/game/game-service.js
@@ -1,0 +1,50 @@
+import axios from 'axios'
+import Raceday from '../raceday/raceday-model.js'
+
+const ATG_BASE_URL = 'https://www.atg.se/services/racinginfo/v1/api'
+
+const mapGamesForRaceday = async (racedayId) => {
+  const raceday = await Raceday.findById(racedayId).lean()
+  if (!raceday) {
+    throw new Error('Raceday not found')
+  }
+
+  const date = raceday.raceDayDate || raceday.firstStart?.toISOString().slice(0, 10)
+  if (!date) {
+    throw new Error('Unable to determine raceday date')
+  }
+
+  const calendarUrl = `${ATG_BASE_URL}/calendar/day/${date}`
+  const calendarResp = await axios.get(calendarUrl)
+  const games = calendarResp.data?.games || {}
+
+  const result = {}
+  const trackName = raceday.trackName
+  const raceList = raceday.raceList || []
+  const raceCache = {}
+
+  for (const [gameType, gameArray] of Object.entries(games)) {
+    for (const game of gameArray) {
+      for (const raceKey of game.races || []) {
+        if (!raceCache[raceKey]) {
+          const raceResp = await axios.get(`${ATG_BASE_URL}/races/${raceKey}`)
+          raceCache[raceKey] = raceResp.data
+        }
+        const raceData = raceCache[raceKey]
+        if (raceData.track?.name !== trackName) continue
+
+        const match = raceList.find(r => r.raceNumber === raceData.number)
+        if (match) {
+          if (!result[gameType]) result[gameType] = []
+          if (!result[gameType].includes(match.raceId)) {
+            result[gameType].push(match.raceId)
+          }
+        }
+      }
+    }
+  }
+
+  return result
+}
+
+export default { mapGamesForRaceday }

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -10,6 +10,7 @@ import raceRoutes from './race/race-routes.js'
 import trackRoutes from './track/track-routes.js'
 import eloRoutes from './rating/elo-routes.js'
 import driverRoutes from './driver/driver-routes.js'
+import gameRoutes from './game/game-routes.js'
 import { startRatingsCronJob } from './rating/ratings-scheduler.js'
 import { startDriverCronJob } from './driver/scheduler.js'
 
@@ -37,6 +38,7 @@ app.use('/api/race', raceRoutes)
 app.use('/api/track', trackRoutes)
 app.use('/api/rating', eloRoutes)
 app.use('/api/driver', driverRoutes)
+app.use('/api/spelformer', gameRoutes)
 
 // 404 handler
 app.use((req, res) => {

--- a/frontend/src/components/SpelformBadge.vue
+++ b/frontend/src/components/SpelformBadge.vue
@@ -1,0 +1,24 @@
+<template>
+  <v-chip :style="{ backgroundColor: bgColor, color: textColor }" class="ma-1" density="compact" label>
+    {{ label }}
+  </v-chip>
+</template>
+
+<script>
+import { getContrastColor } from '@/utils/colors'
+import { getGameColor } from '@/utils/gameColors'
+
+export default {
+  name: 'SpelformBadge',
+  props: {
+    game: { type: String, required: true },
+    leg: { type: Number, required: true }
+  },
+  setup(props) {
+    const bgColor = getGameColor(props.game)
+    const textColor = getContrastColor(bgColor)
+    const label = `${props.game}-${props.leg}`
+    return { bgColor, textColor, label }
+  }
+}
+</script>

--- a/frontend/src/utils/gameColors.js
+++ b/frontend/src/utils/gameColors.js
@@ -1,0 +1,7 @@
+export const GAME_COLORS = {
+  V75: '#ffeb3b',
+  DD: '#f44336',
+  V64: '#2196f3'
+}
+
+export const getGameColor = (code) => GAME_COLORS[code] || '#cccccc'

--- a/frontend/src/views/raceday/RacedayView.vue
+++ b/frontend/src/views/raceday/RacedayView.vue
@@ -10,6 +10,7 @@
               :race="race"
               :lastUpdatedHorseTimestamp="race.earliestUpdatedHorseTimestamp"
               :racedayId="reactiveRouteParams.racedayId"
+              :games="getRaceGames(race.raceId)"
               @race-updated="refreshRaceday"
             />
           </div>
@@ -42,6 +43,7 @@ export default {
     const errorMessage = ref(null)
     const { formatDate } = useDateFormat()
     const reactiveRouteParams = computed(() => route.params)
+    const spelformer = ref({})
     const isRecentlyUpdated = (timestamp) => {
       const sixDaysAgo = new Date()
       sixDaysAgo.setDate(sixDaysAgo.getDate() - 6)
@@ -52,6 +54,7 @@ export default {
     onMounted(async () => {
       try {
         racedayDetails.value = await RacedayService.fetchRacedayDetails(route.params.racedayId)
+        spelformer.value = await RacedayService.fetchSpelformer(route.params.racedayId)
       } catch (error) {
         console.error('Error fetching raceday details:', error)
         errorMessage.value = 'Error fetching raceday details. Please try again later.'
@@ -62,6 +65,7 @@ export default {
     const refreshRaceday = async () => {
       try {
         racedayDetails.value = await RacedayService.fetchRacedayDetails(route.params.racedayId)
+        spelformer.value = await RacedayService.fetchSpelformer(route.params.racedayId)
       } catch (error) {
         console.error('Error refreshing raceday details:', error)
       }
@@ -71,12 +75,23 @@ export default {
       return racedayDetails.value?.raceList.sort((a, b) => a.raceNumber - b.raceNumber) || []
     })
 
+    const getRaceGames = raceId => {
+      const res = []
+      for (const [game, ids] of Object.entries(spelformer.value)) {
+        const idx = ids.indexOf(raceId)
+        if (idx !== -1) res.push({ game, leg: idx + 1 })
+      }
+      return res
+    }
+
     return {
       racedayDetails,
       errorMessage,
       formatDate,
       sortedRaceList,
       reactiveRouteParams,
+      spelformer,
+      getRaceGames,
       isRecentlyUpdated,
       refreshRaceday
     }

--- a/frontend/src/views/raceday/components/RaceCardComponent.vue
+++ b/frontend/src/views/raceday/components/RaceCardComponent.vue
@@ -2,10 +2,15 @@
   <v-card
     class="clickable-card"
     @click="viewRaceDetails"
-    :style="{ '--hover-bg': hoverBg, '--hover-text': hoverText }"
+    :style="{ '--hover-bg': hoverBg, '--hover-text': hoverText, 'background-color': cardColor }"
   >
     <div class="d-flex justify-space-between align-center" style="width: 100%;">
-      <v-card-title> Race Number: {{ race.raceNumber }}</v-card-title>
+      <v-card-title>
+        Race Number: {{ race.raceNumber }}
+        <div class="d-inline-flex ml-2">
+          <SpelformBadge v-for="g in games" :key="g.game" :game="g.game" :leg="g.leg" />
+        </div>
+      </v-card-title>
       <v-card-text>
         <div>
           {{ race.propTexts[0].text + " " + race.propTexts[1].text }}
@@ -26,13 +31,16 @@
 </template>
 
 <script>
-import { toRefs, ref } from 'vue'
+import { toRefs, ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useStore } from 'vuex'
 import { getContrastColor } from '@/utils/colors'
+import { getGameColor } from '@/utils/gameColors'
+import SpelformBadge from '@/components/SpelformBadge.vue'
 import { updateHorse, setEarliestUpdatedHorseTimestamp } from '@/views/race/services/RaceHorsesService.js'
 
 export default {
+  components: { SpelformBadge },
   props: {
     race: {
       type: Object,
@@ -45,11 +53,15 @@ export default {
     racedayId: {
       type: String,
       required: true
+    },
+    games: {
+      type: Array,
+      default: () => []
     }
   },
   setup(props, { emit }) {
     // Convert props to reactive references
-    const { race, lastUpdatedHorseTimestamp } = toRefs(props)
+    const { race, lastUpdatedHorseTimestamp, games } = toRefs(props)
     const router = useRouter()
     const store = useStore()
     const loading = ref(false)
@@ -57,6 +69,12 @@ export default {
 
     const hoverBg = '#f5f5f5'
     const hoverText = getContrastColor(hoverBg)
+    const cardColor = computed(() => {
+      if (games.value.length > 0) {
+        return getGameColor(games.value[0].game)
+      }
+      return undefined
+    })
 
     const viewRaceDetails = () => {
       store.commit('raceHorses/setCurrentRace', props.race);
@@ -93,12 +111,14 @@ export default {
     return {
       race,
       lastUpdatedHorseTimestamp,
+      games,
       viewRaceDetails,
       updateRace,
       loading,
       errorMessage,
       hoverBg,
-      hoverText
+      hoverText,
+      cardColor
     }
   }
 }

--- a/frontend/src/views/raceday/services/RacedayService.js
+++ b/frontend/src/views/raceday/services/RacedayService.js
@@ -11,6 +11,16 @@ const fetchRacedayDetails = async racedayId => {
 }
 
 export default {
-  fetchRacedayDetails
+  fetchRacedayDetails,
+  fetchSpelformer
+}
 
+async function fetchSpelformer(racedayId) {
+  try {
+    const response = await axios.get(`${import.meta.env.VITE_BE_URL}/api/spelformer/${racedayId}`)
+    return response.data
+  } catch (error) {
+    console.error('Error fetching spelformer:', error)
+    throw error
+  }
 }


### PR DESCRIPTION
## Summary
- add backend endpoint `/api/spelformer/:racedayId` to retrieve ATG game mappings for a raceday
- create reusable `SpelformBadge` and color utilities to visualize game legs
- show betting game badges and color-coded cards on raceday list and race view

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688b53165b1c83309f720ca5c856c068