### PR TITLE
feat: reposition spelform badges

### DIFF
--- a/frontend/src/components/SpelformBadge.vue
+++ b/frontend/src/components/SpelformBadge.vue
@@ -1,5 +1,11 @@
 <template>
-  <v-chip :style="{ backgroundColor: bgColor, color: textColor }" class="ma-1" density="compact" label>
+  <v-chip
+    class="spelform-badge"
+    :style="{ backgroundColor: bgColor, color: textColor }"
+    size="small"
+    density="compact"
+    label
+  >
     {{ label }}
   </v-chip>
 </template>
@@ -22,3 +28,10 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.spelform-badge {
+  font-size: 0.75rem;
+  padding: 0 4px;
+}
+</style>

--- a/frontend/src/utils/gameColors.js
+++ b/frontend/src/utils/gameColors.js
@@ -1,7 +1,10 @@
 export const GAME_COLORS = {
-  V75: '#ffeb3b',
-  DD: '#f44336',
-  V64: '#2196f3'
+  V75: '#1e3a8a',
+  V86: '#6b21a8',
+  V64: '#2563eb',
+  GS75: '#be123c',
+  DD: '#f97316',
+  LD: '#16a34a'
 }
 
 export const getGameColor = (code) => GAME_COLORS[code] || '#cccccc'

--- a/frontend/src/views/raceday/components/RaceCardComponent.vue
+++ b/frontend/src/views/raceday/components/RaceCardComponent.vue
@@ -4,28 +4,35 @@
     @click="viewRaceDetails"
     :style="{ '--hover-bg': hoverBg, '--hover-text': hoverText, 'background-color': cardColor }"
   >
-    <div class="d-flex justify-space-between align-center" style="width: 100%;">
-      <v-card-title>
-        Race Number: {{ race.raceNumber }}
-        <div class="d-inline-flex ml-2">
-          <SpelformBadge v-for="g in games" :key="g.game" :game="g.game" :leg="g.leg" />
+    <v-card-title>
+      Race Number: {{ race.raceNumber }}
+    </v-card-title>
+
+    <v-card-text>
+      <div>
+        {{ race.propTexts[0].text + " " + race.propTexts[1].text }}
+        <div v-if="lastUpdatedHorseTimestamp !== null" class="updated-indication">
+          Last Horse Updated: {{ lastUpdatedHorseTimestamp }}
         </div>
-      </v-card-title>
-      <v-card-text>
-        <div>
-          {{ race.propTexts[0].text + " " + race.propTexts[1].text }}
-          <div v-if="lastUpdatedHorseTimestamp !== null" class="updated-indication">
-            Last Horse Updated: {{ lastUpdatedHorseTimestamp }}
-          </div>
-        </div>
-      </v-card-text>
-      <v-card-actions>
-        <v-btn @click.stop="viewRaceDetails">View Details</v-btn>
-        <v-btn @click.stop="updateRace" :disabled="loading" class="ml-2">
-          {{ loading ? 'Updating…' : 'Update Race' }}
-        </v-btn>
-      </v-card-actions>
+      </div>
+    </v-card-text>
+
+    <div class="spelformer-row" v-if="games.length">
+      <SpelformBadge
+        v-for="g in games"
+        :key="`${g.game}-${g.leg}`"
+        :game="g.game"
+        :leg="g.leg"
+      />
     </div>
+
+    <v-card-actions>
+      <v-btn @click.stop="viewRaceDetails">View Details</v-btn>
+      <v-btn @click.stop="updateRace" :disabled="loading" class="ml-2">
+        {{ loading ? 'Updating…' : 'Update Race' }}
+      </v-btn>
+    </v-card-actions>
+
     <v-alert v-if="errorMessage" type="error" class="ma-2">{{ errorMessage }}</v-alert>
   </v-card>
 </template>
@@ -137,5 +144,13 @@ export default {
   background-color: var(--hover-bg);
   color: var(--hover-text);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.spelformer-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 8px;
+  margin-bottom: 4px;
 }
 </style>


### PR DESCRIPTION
## Summary
- move spelform badges to dedicated row with flex styling
- shrink and style spelform badges
- add ATG color palette for major game types

## Testing
- `npm test --prefix frontend` *(fails: Missing script "test")*
- `npm run build --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_688b5a9fda848330ad30c57817fa8dc0