### PR TITLE
feat: cache ATG game data

### DIFF
--- a/backend/src/game/game-routes.js
+++ b/backend/src/game/game-routes.js
@@ -6,11 +6,21 @@ const router = express.Router()
 
 router.get('/:racedayId', validateObjectIdParam('racedayId'), async (req, res) => {
   try {
-    const data = await gameService.mapGamesForRaceday(req.params.racedayId)
+    const data = await gameService.getGameTypesForRaceday(req.params.racedayId)
     res.json(data)
   } catch (err) {
     console.error('Error fetching game types:', err)
     res.status(500).send('Failed to fetch spelformer')
+  }
+})
+
+router.post('/refresh/:racedayId', validateObjectIdParam('racedayId'), async (req, res) => {
+  try {
+    const data = await gameService.refreshGameTypesForRaceday(req.params.racedayId)
+    res.json(data)
+  } catch (err) {
+    console.error('Error refreshing game types:', err)
+    res.status(500).send('Failed to refresh spelformer')
   }
 })
 

--- a/backend/src/raceday/raceday-model.js
+++ b/backend/src/raceday/raceday-model.js
@@ -90,7 +90,9 @@ const racedaySchema = new mongoose.Schema({
   trackName: String,
   raceStandard: String,
   raceDayDate: String,
-  hasPdf: Boolean
+  hasPdf: Boolean,
+  atgCalendarGamesRaw: { type: mongoose.Schema.Types.Mixed, default: {} },
+  gameTypes: { type: mongoose.Schema.Types.Mixed, default: {} }
 })
 
 export default mongoose.model('Raceday', racedaySchema)


### PR DESCRIPTION
## Summary
- store ATG calendar game responses and interpreted mapping on each raceday
- serve cached game types and support manual refresh for a raceday

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint src/game/game-service.js src/game/game-routes.js src/raceday/raceday-model.js` *(fails: Cannot find module './common')*

------
https://chatgpt.com/codex/tasks/task_e_688b63ca355c833096ec165ce4f745a0