### PR TITLE
Fetch and display ATG horse comments

### DIFF
--- a/backend/src/race/race-service.js
+++ b/backend/src/race/race-service.js
@@ -1,15 +1,46 @@
 import Raceday from '../raceday/raceday-model.js'
+import axios from 'axios'
+import Track from '../track/track-model.js'
+
+const ATG_BASE_URL = 'https://www.atg.se/services/racinginfo/v1/api'
 
 const getRaceById = async (id) => {
     try {
-        const raceDay = await Raceday.findOne({"raceList.raceId": id}, 'raceList')
-        
-        if (raceDay) {
-            return raceDay.raceList.find(r => r.raceId.toString() === id.toString())
-        } else {
+        const raceDay = await Raceday.findOne({"raceList.raceId": id})
+
+        if (!raceDay) {
             console.log(`No matching document found for race with ID ${id}.`)
             return null
         }
+
+        const race = raceDay.raceList.find(r => r.raceId.toString() === id.toString())
+        if (!race) {
+            return null
+        }
+
+        const needsComments = race.horses?.some(h => !h.comment)
+        if (needsComments) {
+            const track = await Track.findOne({ trackName: raceDay.trackName }).lean()
+            const trackCode = track ? track.trackCode : raceDay.trackName
+            const raceKey = `${raceDay.raceDayDate}_${trackCode}_${race.raceNumber}`
+            try {
+                const resp = await axios.get(`${ATG_BASE_URL}/races/${raceKey}/extended`)
+                const ext = resp.data
+                race.atgExtendedRaw = ext
+                for (const extHorse of ext.horses || []) {
+                    const match = race.horses.find(h => h.id === extHorse.id)
+                    if (match) {
+                        match.comment = extHorse.comment
+                    }
+                }
+                raceDay.markModified('raceList')
+                await raceDay.save()
+            } catch (e) {
+                console.error(`Failed to fetch extended data for race ${raceKey}: ${e.message}`)
+            }
+        }
+
+        return race
     } catch (err) {
         console.error(`Error fetching race with ID ${id}: ${err.message}`)
         throw new Error('Failed to retrieve race')

--- a/backend/src/raceday/raceday-model.js
+++ b/backend/src/raceday/raceday-model.js
@@ -51,7 +51,8 @@ const horseSchema = new mongoose.Schema({
   },
   horseWithdrawn: Boolean,
   driverChanged: Boolean,
-  linkable: Boolean
+  linkable: Boolean,
+  comment: String
 })
 
 const propTextsSchema = new mongoose.Schema({
@@ -76,7 +77,8 @@ const raceSchema = new mongoose.Schema({
   horses: [horseSchema],
   propTexts: [propTextsSchema],
   startDateTime: Date,
-  resultsReady: Boolean
+  resultsReady: Boolean,
+  atgExtendedRaw: { type: mongoose.Schema.Types.Mixed, default: {} }
 })
 
 const racedaySchema = new mongoose.Schema({

--- a/frontend/src/views/race/RaceHorsesView.vue
+++ b/frontend/src/views/race/RaceHorsesView.vue
@@ -56,6 +56,14 @@
                                     {{ formatShoe(item.raw) }}
                                 </span>
                             </template>
+                            <template v-slot:item.comment="{ item }">
+                                <v-tooltip v-if="item.columns.comment">
+                                    <template #activator="{ props }">
+                                        <v-icon v-bind="props" size="small">mdi-information-outline</v-icon>
+                                    </template>
+                                    <span>{{ item.columns.comment }}</span>
+                                </v-tooltip>
+                            </template>
                         </v-data-table>
                     </v-window-item>
                     <v-window-item value="1">
@@ -424,6 +432,7 @@ export default {
                 const index = showStartPositionColumn.value ? 2 : 1
                 base.splice(index, 0, { title: 'Distans', key: 'actualDistance' })
             }
+            base.push({ title: 'Kommentar', key: 'comment', sortable: false })
             return base
         })
 


### PR DESCRIPTION
## Summary
- cache ATG race extended data and store comment per horse in DB
- fetch ATG extended when missing comments and expose through race API
- show horse comment tooltip in start list

## Testing
- `npm test` (backend) *(fails: Missing script)*
- `npx eslint .` *(fails: Cannot find module './common')*
- `npm test` (frontend) *(fails: Missing script)*
- `npm run build` (frontend) *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b819a223c8330ba01323fb2dbd85f