### PR TITLE
feat: show horse comments and past race notes

### DIFF
--- a/frontend/src/views/race/RaceHorsesView.vue
+++ b/frontend/src/views/race/RaceHorsesView.vue
@@ -47,9 +47,14 @@
                                 {{ item.columns.actualDistance ? `${item.columns.actualDistance} m` : '—' }}
                             </template>
                             <template v-slot:item.name="{ item }">
-                                <span :style="{ 'text-decoration': item.columns.horseWithdrawn ? 'line-through' : 'none' }">
-                                    {{ item.columns.name }}
-                                </span>
+                                <div :class="{ withdrawn: item.columns.horseWithdrawn }">
+                                    <div>{{ item.columns.name }}</div>
+                                    <HorseCommentBlock
+                                      :comment="item.columns.comment"
+                                      :past-race-comments="item.raw.pastRaceComments"
+                                      :withdrawn="item.columns.horseWithdrawn"
+                                    />
+                                </div>
                             </template>
                             <template v-slot:item.eloRating="{ item }">
                                 {{ formatElo(item.columns.eloRating) }}
@@ -61,9 +66,6 @@
                                 <span :title="shoeTooltip(item.raw) || null">
                                     {{ formatShoe(item.raw) }}
                                 </span>
-                            </template>
-                            <template v-slot:item.comment="{ item }">
-                              {{ item.columns.comment }}
                             </template>
                         </v-data-table>
                     </v-window-item>
@@ -119,10 +121,11 @@ import {
 import RacedayService from '@/views/raceday/services/RacedayService.js'
 import TrackService from '@/views/race/services/TrackService.js'
 import SpelformBadge from '@/components/SpelformBadge.vue'
+import HorseCommentBlock from './components/HorseCommentBlock.vue'
 
 export default {
     name: 'RaceHorsesView',
-    components: { SpelformBadge },
+    components: { SpelformBadge, HorseCommentBlock },
 
     setup() {
         // Helper to parse start method and handicaps from propTexts
@@ -433,7 +436,6 @@ export default {
                 const index = showStartPositionColumn.value ? 2 : 1
                 base.splice(index, 0, { title: 'Distans', key: 'actualDistance' })
             }
-            base.push({ title: 'Kommentar', key: 'comment', sortable: false })
             return base
         })
 
@@ -620,5 +622,9 @@ export default {
 
 .race-navigation {
     margin-top: 16px;
+}
+
+.withdrawn {
+    text-decoration: line-through;
 }
 </style>

--- a/frontend/src/views/race/components/HorseCommentBlock.vue
+++ b/frontend/src/views/race/components/HorseCommentBlock.vue
@@ -1,0 +1,62 @@
+<template>
+  <div v-if="hasContent" :class="['horse-comment-block', { withdrawn }]">
+    <div v-if="comment" class="main-comment">{{ comment }}</div>
+    <ul v-if="formattedPastComments.length" class="past-comments">
+      <li v-for="(pc, idx) in formattedPastComments" :key="idx">
+        <span class="arrow">\u2192</span>
+        {{ pc }}
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+import { computed } from 'vue'
+import { formatPastComment } from '../services/formatPastComment.js'
+
+export default {
+  name: 'HorseCommentBlock',
+  props: {
+    comment: String,
+    pastRaceComments: Array,
+    withdrawn: Boolean
+  },
+  setup(props) {
+    const formattedPastComments = computed(() => {
+      const list = (props.pastRaceComments || [])
+        .slice()
+        .sort((a, b) => new Date(b.date) - new Date(a.date))
+        .slice(0, 3)
+        .map(formatPastComment)
+      return list
+    })
+
+    const hasContent = computed(() => !!(props.comment || formattedPastComments.value.length))
+
+    return { formattedPastComments, hasContent }
+  }
+}
+</script>
+
+<style scoped>
+.horse-comment-block {
+  font-size: 11px;
+  color: #666;
+}
+.main-comment {
+  margin-top: 2px;
+}
+.past-comments {
+  padding-left: 0;
+  margin: 2px 0 0 0;
+  list-style: none;
+  font-size: 10px;
+  color: #888;
+}
+.past-comments .arrow {
+  margin-right: 4px;
+}
+.withdrawn {
+  text-decoration: line-through;
+}
+</style>

--- a/frontend/src/views/race/services/formatPastComment.js
+++ b/frontend/src/views/race/services/formatPastComment.js
@@ -1,0 +1,5 @@
+export function formatPastComment({ date, track, comment, driver }) {
+  const d = date ? new Date(date).toISOString().split('T')[0] : '';
+  const driverPart = driver ? ` (${driver})` : '';
+  return `${d}, ${track}: "${comment}${driverPart}"`;
+}


### PR DESCRIPTION
## Summary
- display horse comment and latest past race notes below each name
- format past race notes via `formatPastComment` helper
- strike through withdrawn horses and comments

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688c70b56c3c8330ade93ac8feb8e585