### PR TITLE
Ensure past race place is shown in comments

### DIFF
--- a/backend/src/race/race-service.js
+++ b/backend/src/race/race-service.js
@@ -46,14 +46,18 @@ const extractPastRaceComments = (records) =>
             const hasComment = r?.trMediaInfo?.comment?.trim() || r?.trMediaInfo?.commentText?.trim()
             return !isQualifier && hasComment
         })
-        .map(r => ({
-            date: r?.race?.startTime || r?.race?.date || r?.startTime || r?.date,
-            comment: r?.trMediaInfo?.comment?.trim() || r?.trMediaInfo?.commentText?.trim(),
-            raceId: r?.race?.id,
-            driver: r?.driver?.name || [r?.driver?.firstName, r?.driver?.lastName].filter(Boolean).join(' '),
-            track: r?.race?.track?.name || r?.track?.name,
-            place: r?.place || ''
-        }))
+        .map(r => {
+            const record = {
+                date: r?.race?.startTime || r?.race?.date || r?.startTime || r?.date,
+                comment: r?.trMediaInfo?.comment?.trim() || r?.trMediaInfo?.commentText?.trim(),
+                raceId: r?.race?.id,
+                driver: r?.driver?.name || [r?.driver?.firstName, r?.driver?.lastName].filter(Boolean).join(' '),
+                track: r?.race?.track?.name || r?.track?.name,
+                place: r?.place ?? null
+            }
+            console.log('🧪 Extracted record:', record.place)
+            return record
+        })
 
 /**
  * Apply extended race data to the horses in the race object.

--- a/frontend/src/views/race/components/HorseCommentBlock.vue
+++ b/frontend/src/views/race/components/HorseCommentBlock.vue
@@ -11,7 +11,7 @@
         <span class="arrow">→</span>
         <span :class="commentClass(pc.comment)">
           <strong>{{ pc.date }}</strong>
-          <span v-if="pc.place"> ({{ pc.place }})</span>
+          <span> ({{ formatPlace(pc.place) }})</span>
           {{ pc.comment }}
         </span>
       </li>
@@ -44,11 +44,14 @@ export default {
       (props.pastRaceComments || [])
         .slice()
         .sort((a, b) => new Date(b.date) - new Date(a.date))
-        .map(pc => ({
-          date: pc.date?.split('T')[0] || '',
-          place: pc.place || '',
-          comment: pc.comment || ''
-        }))
+        .map(pc => {
+          console.log('🧪 Past comment place:', pc.place)
+          return {
+            date: pc.date?.split('T')[0] || '',
+            place: pc.place ?? null,
+            comment: pc.comment || ''
+          }
+        })
     )
 
     const visiblePastComments = computed(() =>
@@ -74,12 +77,18 @@ export default {
 
     console.log('Formatted past comments:', formattedPastComments.value)
 
+    const formatPlace = place =>
+      place === 0 || place === null || place === undefined || place === ''
+        ? '**'
+        : place
+
     return {
       formattedPastComments,
       visiblePastComments,
       extraCommentsCount,
       showAll,
-      commentClass
+      commentClass,
+      formatPlace
     }
     
   }


### PR DESCRIPTION
## Summary
- Always include and log `place` when extracting past race comments on the backend
- Preserve and format `place` in `HorseCommentBlock.vue`, showing `(**)` when the value is missing or zero

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `npm test` (frontend) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688cc7f293b8833087d71751aab79638