### PR TITLE
Ensure past race comments always include place

### DIFF
--- a/backend/src/race/race-service.js
+++ b/backend/src/race/race-service.js
@@ -46,18 +46,14 @@ const extractPastRaceComments = (records) =>
             const hasComment = r?.trMediaInfo?.comment?.trim() || r?.trMediaInfo?.commentText?.trim()
             return !isQualifier && hasComment
         })
-        .map(r => {
-            const record = {
-                date: r?.race?.startTime || r?.race?.date || r?.startTime || r?.date,
-                comment: r?.trMediaInfo?.comment?.trim() || r?.trMediaInfo?.commentText?.trim(),
-                raceId: r?.race?.id,
-                driver: r?.driver?.name || [r?.driver?.firstName, r?.driver?.lastName].filter(Boolean).join(' '),
-                track: r?.race?.track?.name || r?.track?.name,
-                place: r?.place ?? null
-            }
-            console.log('🧪 Extracted record:', record.place)
-            return record
-        })
+        .map(r => ({
+            date: r?.race?.startTime || r?.race?.date || r?.startTime || r?.date,
+            comment: r?.trMediaInfo?.comment?.trim() || r?.trMediaInfo?.commentText?.trim(),
+            raceId: r?.race?.id,
+            driver: r?.driver?.name || [r?.driver?.firstName, r?.driver?.lastName].filter(Boolean).join(' '),
+            track: r?.race?.track?.name || r?.track?.name,
+            place: Number(r?.place ?? 0)
+        }))
 
 /**
  * Apply extended race data to the horses in the race object.

--- a/backend/src/raceday/raceday-model.js
+++ b/backend/src/raceday/raceday-model.js
@@ -59,7 +59,8 @@ const horseSchema = new mongoose.Schema({
       comment: String,
       raceId: String,
       driver: String,
-      track: String
+      track: String,
+      place: { type: Number, default: 0 }
     }
   ]
 })

--- a/frontend/src/views/race/components/HorseCommentBlock.vue
+++ b/frontend/src/views/race/components/HorseCommentBlock.vue
@@ -44,14 +44,11 @@ export default {
       (props.pastRaceComments || [])
         .slice()
         .sort((a, b) => new Date(b.date) - new Date(a.date))
-        .map(pc => {
-          console.log('🧪 Past comment place:', pc.place)
-          return {
-            date: pc.date?.split('T')[0] || '',
-            place: pc.place ?? null,
-            comment: pc.comment || ''
-          }
-        })
+        .map(pc => ({
+          date: pc.date?.split('T')[0] || '',
+          place: Number(pc.place ?? 0),
+          comment: pc.comment || ''
+        }))
     )
 
     const visiblePastComments = computed(() =>


### PR DESCRIPTION
## Summary
- Guarantee `place` is always populated in past race comments with a numeric value, defaulting to 0 when missing.
- Expand race day model to store `place` for past race comments with a default of 0.
- Normalize past race comment data on the frontend to always provide a numeric `place` value.

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688ccbb1d2208330adcb3914953395dd