### PR TITLE
Use Travsport results for horse stats

### DIFF
--- a/backend/src/race/race-service.js
+++ b/backend/src/race/race-service.js
@@ -36,10 +36,10 @@ const resolveTrackId = async (raceDay) => {
 }
 
 /**
- * Extract past race comments from the start's result records.
+ * Extract past race comments from the horse's results.
  */
-const extractPastRaceComments = (records) =>
-    (records || [])
+const extractPastRaceComments = (results) =>
+    (results || [])
         .filter(r => {
             const raceType = r?.race?.type || r?.type || ''
             const isQualifier = raceType.toLowerCase().includes('qual')
@@ -73,7 +73,7 @@ const applyExtendedData = (race, starts = []) => {
         }
 
         if (!match.pastRaceComments || match.pastRaceComments.length === 0) {
-            const pastRaceComments = extractPastRaceComments(start.horse?.results?.records)
+            const pastRaceComments = extractPastRaceComments(start.horse?.results)
             if (pastRaceComments.length) {
                 match.pastRaceComments = pastRaceComments
                 console.log(`📜 Stored ${pastRaceComments.length} past comments for horse ${horseId}`)

--- a/frontend/src/views/race/RaceHorsesView.vue
+++ b/frontend/src/views/race/RaceHorsesView.vue
@@ -382,8 +382,8 @@ export default {
                     driverRatingMap[String(d.id)] = d.elo
                 })
                 const computeHorseStats = (horse) => {
-                    const records = horse.results?.records || horse.results || []
-                    const totalStarts = records.length
+                    const results = horse.results || []
+                    const totalStarts = results.length
                     let wins = 0
                     let top3 = 0
                     let sumPlacings = 0
@@ -393,7 +393,7 @@ export default {
                     let favDriver = ''
                     let favCount = 0
 
-                    records.forEach((r, idx) => {
+                    results.forEach((r, idx) => {
                         const placement = Number(r?.placement?.sortValue ?? r?.placement ?? 0)
                         if (placement === 1) wins++
                         if (placement >= 1 && placement <= 3) top3++


### PR DESCRIPTION
## Summary
- use `horse.results` directly when computing horse statistics
- pull past race comments from Travsport results rather than ATG records

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688ded40c2b88330bc7a2ca89c600308