### PR TITLE
fix: derive horse stats from Travsport results

### DIFF
--- a/frontend/src/views/race/RaceHorsesView.vue
+++ b/frontend/src/views/race/RaceHorsesView.vue
@@ -397,7 +397,7 @@ export default {
                 })
                 const computeHorseStats = (horse) => {
                     const results = Array.isArray(horse.results) ? horse.results : []
-                    const totalStarts = results.length
+                    let totalStarts = 0
                     let wins = 0
                     let top3 = 0
                     let sumPlacings = 0
@@ -428,7 +428,7 @@ export default {
                         return null
                     }
 
-                    records.forEach((r, idx) => {
+                    results.forEach((r, idx) => {
                         if (r.withdrawn) return
                         totalStarts++
                         const placement = Number(r?.placement?.sortValue ?? r?.placement ?? 0)


### PR DESCRIPTION
## Summary
- prevent crash by making `totalStarts` mutable and incrementing only for non-withdrawn results
- remove `records` usage in favor of `horse.results` and verify it's an array
- compute horse statistics exclusively from Travsport results

## Testing
- `npm test` (frontend) *(fails: Missing script)*
- `npm test` (backend) *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688e02647f28833095f598a4869076ca