### PR TITLE
fix: handle nested results records in horse stats

### DIFF
--- a/frontend/src/views/race/RaceHorsesView.vue
+++ b/frontend/src/views/race/RaceHorsesView.vue
@@ -398,12 +398,14 @@ export default {
                     driverRatingMap[String(d.id)] = d.elo
                 })
                 // Stats based on Travsport data (horse.results[]). ATG past-race
-                // objects expose a `.records` property, but that structure is not
-                // used here.
+                // objects may expose a `.records` property, so handle both
+                // shapes when gathering result data.
                 const statsFor = (horse) => {
-                    const results = Array.isArray(horse.results)
-                        ? [...horse.results]
-                        : []
+                    const results = Array.isArray(horse.results?.records)
+                        ? [...horse.results.records]
+                        : Array.isArray(horse.results)
+                            ? [...horse.results]
+                            : []
                     // Sort most recent first so that form is calculated on the
                     // latest starts
                     results.sort((a, b) =>


### PR DESCRIPTION
## Summary
- support `results.records` in horse stats calculation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e3878bda88330804c685e9c594751