### PR TITLE
Expose horse stats on race table

### DIFF
--- a/frontend/src/views/race/RaceHorsesView.vue
+++ b/frontend/src/views/race/RaceHorsesView.vue
@@ -68,11 +68,11 @@
                                 {{ item.raw.driver?.name }} – {{ formatElo(item.columns.driverElo) }}
                             </template>
                             <template v-slot:item.stats="{ item }">
-                                <span v-if="item.raw.statsTotalStarts">
+                                <span v-if="item.raw.stats?.totalStarts">
                                     {{
-                                        `${item.raw.statsTotalStarts} starts, ` +
-                                        `${Math.round(item.raw.statsWinPercentage)}% win, ` +
-                                        `${Math.round(item.raw.statsTop3Percentage)}% top3`
+                                        `${item.raw.stats.totalStarts} starts, ` +
+                                        `${Math.round(item.raw.stats.winPercentage)}% win, ` +
+                                        `${Math.round(item.raw.stats.top3Percentage)}% top3`
                                     }}
                                 </span>
                                 <span v-else>
@@ -614,6 +614,7 @@ export default {
                     const stats = statsFor(h)
                     return {
                         ...h,
+                        stats,
                         score: scoreMap[h.id],
                         rating: ratingMap[h.id],
                         eloRating: ratingMap[h.id],


### PR DESCRIPTION
## Summary
- expose `stats` on each horse when mapping race horses
- render race table stats slot using `item.raw.stats`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e3879526c8330b8e5548620f5a8a3