### PR TITLE
Fetch horse stats before calculating race statistics

### DIFF
--- a/frontend/src/views/race/services/HorseService.js
+++ b/frontend/src/views/race/services/HorseService.js
@@ -1,0 +1,15 @@
+import axios from 'axios'
+
+const getHorseById = async (id) => {
+  try {
+    const response = await axios.get(`${import.meta.env.VITE_BE_URL}/api/horses/${id}`)
+    return response.data
+  } catch (error) {
+    console.error(`Failed to fetch horse with id ${id}:`, error)
+    throw error
+  }
+}
+
+export default {
+  getHorseById,
+}


### PR DESCRIPTION
## Summary
- fetch each horse's full details via `HorseService.getHorseById` and compute stats
- expose stats as flattened fields used by table

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e3fe8bc648330b8250b0d3e16859d